### PR TITLE
fix: refresh dm paths, increase attempts, 10s delay plus debug

### DIFF
--- a/iscsi/iscsi.go
+++ b/iscsi/iscsi.go
@@ -19,7 +19,7 @@ import (
 const (
 	defaultPort          = "3260"
 	maxMultipathAttempts = 10
-	multipathDelay       = 30
+	multipathDelay       = 10
 )
 
 var (
@@ -162,7 +162,7 @@ func waitForPathToExistImpl(devicePath *string, maxRetries, intervalSeconds int,
 		err = nil
 		if deviceTransport == "tcp" {
 			_, err = osStat(*devicePath)
-			debug.Printf("os stat device: exist %v device %v", !os.IsNotExist(err), *devicePath)
+			debug.Printf("[%d] os stat device: exist %v device %v", i, !os.IsNotExist(err), *devicePath)
 			if err != nil && !os.IsNotExist(err) {
 				debug.Printf("Error attempting to stat device: %s", err.Error())
 				return false, err
@@ -171,7 +171,7 @@ func waitForPathToExistImpl(devicePath *string, maxRetries, intervalSeconds int,
 			}
 
 		} else {
-			debug.Printf("filepathGlob: %s", *devicePath)
+			debug.Printf("[%d] filepathGlob: %s", i, *devicePath)
 			fpath, _ := filepathGlob(*devicePath)
 			if fpath == nil {
 				err = os.ErrNotExist
@@ -191,6 +191,7 @@ func waitForPathToExistImpl(devicePath *string, maxRetries, intervalSeconds int,
 		}
 		time.Sleep(time.Second * time.Duration(intervalSeconds))
 	}
+	debug.Printf("device does NOT exist [%d*%ds] (%v)", maxRetries, intervalSeconds, *devicePath)
 	return false, err
 }
 

--- a/iscsi/multipath.go
+++ b/iscsi/multipath.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"syscall"
 	"time"
 )
 
@@ -112,8 +111,8 @@ func RemoveAndClear(device string) error {
 	debug.Printf("dmsetup remove -f %s\n", device)
 	if output, err := execCommand("dmsetup", "remove", "-f", device).CombinedOutput(); err != nil {
 		exitErr, ok := err.(*exec.ExitError)
-		if ok && exitErr.ProcessState.Sys().(syscall.WaitStatus).ExitStatus() != 0 {
-			debug.Printf("ERROR: dmsetup remove -f ExitStatus: %d, err=%v\n", exitErr.ProcessState.Sys().(syscall.WaitStatus).ExitStatus(), err)
+		if ok && exitErr.ExitCode() != 0 {
+			debug.Printf("ERROR: dmsetup remove -f ExitCode: %d, err=%v\n", exitErr.ExitCode(), err)
 		}
 
 		return fmt.Errorf("device-mapper could not remove device: %s (%v)", output, err)

--- a/iscsi/multipath.go
+++ b/iscsi/multipath.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"syscall"
 	"time"
 )
 
@@ -108,7 +109,13 @@ func RemoveAndClear(device string) error {
 	debug.Printf("Remove and clear multipath device (%s)\n", device)
 
 	// Remove device-mapper logical device
+	debug.Printf("dmsetup remove -f %s\n", device)
 	if output, err := execCommand("dmsetup", "remove", "-f", device).CombinedOutput(); err != nil {
+		exitErr, ok := err.(*exec.ExitError)
+		if ok && exitErr.ProcessState.Sys().(syscall.WaitStatus).ExitStatus() != 0 {
+			debug.Printf("ERROR: dmsetup remove -f ExitStatus: %d, err=%v\n", exitErr.ProcessState.Sys().(syscall.WaitStatus).ExitStatus(), err)
+		}
+
 		return fmt.Errorf("device-mapper could not remove device: %s (%v)", output, err)
 	}
 
@@ -116,6 +123,7 @@ func RemoveAndClear(device string) error {
 	if _, e := os.Stat(device); os.IsNotExist(e) {
 		debug.Printf("device-mapper logical device %q was removed\n", device)
 	} else {
+		debug.Printf("dmsetup clear %s\n", device)
 		if output, err := execCommand("dmsetup", "clear", device).CombinedOutput(); err != nil {
 			return fmt.Errorf("device-mapper could not clear device: %s (%v)", output, err)
 		}


### PR DESCRIPTION
- Added additional debug to RemoveAndClear() to trace through operating system clean up items.
- The goal of getMultipathDisk() is to discover the correct /dev/dm-# for multiple paths to a volume. This routine was updated to correctly update the list of devices for each search attempt. The number of attempts was increased to 10 (originally it was 3 attempts) and the delay between attempts was increased form 1 second to 30 seconds. During heavy operating system activity, and errors, it was taking the multipath daemon several minutes to create the new multipath device and this function was giving up too quickly. 95% of calls to NodePublishVolume() do not require multiple attempts, so this delay only affects a small subset of calls. Just under 5% of NodePublishVolume() calls require two (2) attempts, which results in a 30s delay, but the overall speed of this version of the driver is 2 times faster at producing 200 PODs and PVCs.
- Note, this routine is no longer in the kubernetes-csi/csi-lib-iscsi, but that library does not work properly under heavy testing and requires additional corrections and testing.