### PR TITLE
Refactor/klogs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build clean install
+.PHONY: all build clean install test coverage
 
 all: clean build install
 
@@ -16,3 +16,6 @@ install:
 test:
 	go test ./iscsi/
 
+coverage:
+	go test ./iscsi -coverprofile=coverage.out
+	go tool cover -html=coverage.out

--- a/OWNERS
+++ b/OWNERS
@@ -1,8 +1,16 @@
 # See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
 
 approvers:
-- saad-ali
+- humblec
 - j-griffith
-reviews:
+- jsafrane
+- msau42
 - saad-ali
+- xing-yang
+reviewers:
+- humblec
 - j-griffith
+- jsafrane
+- msau42
+- saad-ali
+- xing-yang

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ golang libs.  This may prove to not be ideal, and may be changed over time, but 
 
 ## Logging and Debug
 
-This library uses klog/v2 with structured and contextual logging to produce InfoS and ErrorS log entries. A caller
+This library uses klog/v2 with structured and contextual logging to produce Info and Error log entries. A caller
 can change the verbosity level by using the command line option of "-v=#" and using "-v=0" will not produce any
 log entries. To increase the verbosity of the log entries, use "-v=2". External functions require context.Context
 and the logger is extracted from the context using klog.FromContext(ctx), and then a logger pointer is passed around

--- a/README.md
+++ b/README.md
@@ -17,14 +17,18 @@ golang libs.  This may prove to not be ideal, and may be changed over time, but 
 
 ## Logging and Debug
 
-By default the library uses klog and structured logging to produce InfoS and ErrorS log entries. A caller can replace
-the default io.Writer with their own by using the provided function:
+This library uses klog/v2 with structured and contextual logging to produce InfoS and ErrorS log entries. A caller
+can change the verbosity level by using the command line option of "-v=#" and using "-v=0" will not produce any
+log entries. To increase the verbosity of the log entries, use "-v=2". External functions require context.Context
+and the logger is extracted from the context using klog.FromContext(ctx), and then a logger pointer is passed around
+to internal functions that rely on InfoS and ErrorS calls.
 
-```
-func EnableDebugLogging(writer io.Writer)
-```
+## External Binary Dependencies
 
-This direct logging to the provided io.Writer and include the response of every iscsiadm command issued.
+This library relies on the following operating system executables:
+* iscsiadm - Open-iscsi administration utility.
+* multipath - Device mapper target autoconfig.
+* multipathd - Multipath daemon.
 
 ## Intended Usage
 

--- a/README.md
+++ b/README.md
@@ -17,20 +17,19 @@ golang libs.  This may prove to not be ideal, and may be changed over time, but 
 
 ## Logging and Debug
 
-By default the library does not provide any logging, but provides an error message that includes any messages from
-iscsiadm as well as exit-codes.  In the event that you need to debug the library, we provide a function:
+By default the library uses klog and structured logging to produce InfoS and ErrorS log entries. A caller can replace
+the default io.Writer with their own by using the provided function:
 
 ```
 func EnableDebugLogging(writer io.Writer)
 ```
 
-This will turn on verbose logging directed to the provided io.Writer and include the response of every iscsiadm command
-issued.
+This direct logging to the provided io.Writer and include the response of every iscsiadm command issued.
 
 ## Intended Usage
 
-Curently the intended usage of this library is simply to provide a golang package to standardize how plugins are implementing
-iscsi connect and disconnect.  It's not intended to be  a "service", although that's a possible next step.  It's currenty been
+Currently the intended usage of this library is simply to provide a golang package to standardize how plugins are implementing
+iscsi connect and disconnect.  It's not intended to be  a "service", although that's a possible next step.  It's currently been
 used for plugins where iscsid is installed in containers only, as well as designs where it uses the nodes iscsid.  Each of these
 approaches has their own pros and cons.  Currently, it's up to the plugin author to determine which model suits them best
 and to deploy their node plugin appropriately.

--- a/example/main.go
+++ b/example/main.go
@@ -26,25 +26,14 @@ func main() {
 		iscsi.EnableDebugLogging(os.Stdout)
 	}
 
-	var targets []iscsi.TargetInfo
-
-	for _, tgtp := range tgtps {
-		parts := strings.Split(tgtp, ":")
-		targets = append(targets, iscsi.TargetInfo{
-			// Specify the target iqn we're dealing with
-			Iqn:    *iqn,
-			Portal: parts[0],
-			Port:   parts[1],
-		})
-	}
-
 	// You can utilize the iscsiadm calls directly if you wish, but by creating a Connector
 	// you can simplify interactions to simple calls like "Connect" and "Disconnect"
 	c := &iscsi.Connector{
 		// Our example uses chap
 		AuthType: "chap",
 		// List of targets must be >= 1 (>1 signals multipath/mpio)
-		Targets: targets,
+		TargetIqn:     *iqn,
+		TargetPortals: tgtps,
 		// CHAP can be setup up for discovery as well as sessions, our example
 		// device only uses CHAP security for sessions, for those that use Discovery
 		// as well, we'd add a DiscoverySecrets entry the same way

--- a/example/main.go
+++ b/example/main.go
@@ -13,7 +13,6 @@ import (
 var (
 	portals   = flag.String("portals", "192.168.1.112:3260", "Comma delimited.  Eg: 1.1.1.1,2.2.2.2")
 	iqn       = flag.String("iqn", "iqn.2010-10.org.openstack:volume-95739000-1557-44f8-9f40-e9d29fe6ec47", "")
-	multipath = flag.Bool("multipath", false, "")
 	username  = flag.String("username", "3aX7EEf3CEgvESQG75qh", "")
 	password  = flag.String("password", "eJBDC7Bt7WE3XFDq", "")
 	lun       = flag.Int("lun", 1, "")
@@ -41,7 +40,7 @@ func main() {
 
 	// You can utilize the iscsiadm calls directly if you wish, but by creating a Connector
 	// you can simplify interactions to simple calls like "Connect" and "Disconnect"
-	c := iscsi.Connector{
+	c := &iscsi.Connector{
 		// Our example uses chap
 		AuthType: "chap",
 		// List of targets must be >= 1 (>1 signals multipath/mpio)
@@ -55,8 +54,6 @@ func main() {
 			SecretsType: "chap"},
 		// Lun is the lun number the devices uses for exports
 		Lun: int32(*lun),
-		// Multipath indicates that we want to configure this connection as a multipath device
-		Multipath: *multipath,
 		// Number of times we check for device path, waiting for CheckInterval seconds inbetween each check (defaults to 10 if omitted)
 		RetryCount: 11,
 		// CheckInterval is the time in seconds to wait inbetween device path checks when logging in to a target
@@ -68,11 +65,6 @@ func main() {
 	path, err := iscsi.Connect(c)
 	if err != nil {
 		log.Printf("Error returned from iscsi.Connect: %s", err.Error())
-		os.Exit(1)
-	}
-
-	if path == "" {
-		log.Printf("Failed to connect, didn't receive a path, but also no error!")
 		os.Exit(1)
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,17 @@
-module github.com/kubernetes-csi/csi-lib-iscsi
+module github.com/Seagate/csi-lib-iscsi
 
-go 1.15
+go 1.18
 
 require (
+	github.com/kubernetes-csi/csi-lib-iscsi v0.0.0-20220106022228-366f3190694e
 	github.com/prashantv/gostub v1.0.0
 	github.com/stretchr/testify v1.7.0
+	k8s.io/klog/v2 v2.60.1
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/go-logr/logr v1.2.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/kubernetes-csi/csi-lib-iscsi
 
 go 1.15
 
-require github.com/prashantv/gostub v1.0.0
+require (
+	github.com/prashantv/gostub v1.0.0
+	github.com/stretchr/testify v1.7.0
+)

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/kubernetes-csi/csi-lib-iscsi
 
 go 1.15
+
+require github.com/prashantv/gostub v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/kubernetes-csi/csi-lib-iscsi
+
+go 1.15

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/Seagate/csi-lib-iscsi
+module github.com/kubernetes-csi/csi-lib-iscsi
 
 go 1.18
 

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/kubernetes-csi/csi-lib-iscsi
 go 1.18
 
 require (
+	github.com/go-logr/logr v1.2.0
 	github.com/prashantv/gostub v1.0.0
 	github.com/stretchr/testify v1.7.0
 	k8s.io/klog/v2 v2.60.1
@@ -10,7 +11,6 @@ require (
 
 require (
 	github.com/davecgh/go-spew v1.1.0 // indirect
-	github.com/go-logr/logr v1.2.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/kubernetes-csi/csi-lib-iscsi
 go 1.18
 
 require (
-	github.com/kubernetes-csi/csi-lib-iscsi v0.0.0-20220106022228-366f3190694e
 	github.com/prashantv/gostub v1.0.0
 	github.com/stretchr/testify v1.7.0
 	k8s.io/klog/v2 v2.60.1

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/prashantv/gostub v1.0.0 h1:wTzvgO04xSS3gHuz6Vhuo0/kvWelyJxwNS0IRBPAwGY=
+github.com/prashantv/gostub v1.0.0/go.mod h1:dP1v6T1QzyGJJKFocwAU0lSZKpfjstjH8TlhkEU0on0=

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,7 @@ github.com/prashantv/gostub v1.0.0/go.mod h1:dP1v6T1QzyGJJKFocwAU0lSZKpfjstjH8Tl
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,12 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prashantv/gostub v1.0.0 h1:wTzvgO04xSS3gHuz6Vhuo0/kvWelyJxwNS0IRBPAwGY=
 github.com/prashantv/gostub v1.0.0/go.mod h1:dP1v6T1QzyGJJKFocwAU0lSZKpfjstjH8TlhkEU0on0=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,9 @@
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/go-logr/logr v1.2.0 h1:QK40JKJyMdUDz+h+xvCsru/bJhvG0UxvePV0ufL/AcE=
+github.com/go-logr/logr v1.2.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
+github.com/kubernetes-csi/csi-lib-iscsi v0.0.0-20220106022228-366f3190694e h1:krLbHxbBpekmhDPqQoV1IvMlajXKPumDBIfbW0e4zbs=
+github.com/kubernetes-csi/csi-lib-iscsi v0.0.0-20220106022228-366f3190694e/go.mod h1:c/keGS6bErOzLrFyNgafdDWT6h72v2XQiA/p2R7yghU=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prashantv/gostub v1.0.0 h1:wTzvgO04xSS3gHuz6Vhuo0/kvWelyJxwNS0IRBPAwGY=
@@ -11,3 +15,5 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+k8s.io/klog/v2 v2.60.1 h1:VW25q3bZx9uE3vvdL6M8ezOX79vA2Aq1nEWLqNQclHc=
+k8s.io/klog/v2 v2.60.1/go.mod h1:y1WjHnz7Dj687irZUWR/WLkLc5N1YHtjLdmgWjndZn0=

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,6 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-logr/logr v1.2.0 h1:QK40JKJyMdUDz+h+xvCsru/bJhvG0UxvePV0ufL/AcE=
 github.com/go-logr/logr v1.2.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
-github.com/kubernetes-csi/csi-lib-iscsi v0.0.0-20220106022228-366f3190694e h1:krLbHxbBpekmhDPqQoV1IvMlajXKPumDBIfbW0e4zbs=
-github.com/kubernetes-csi/csi-lib-iscsi v0.0.0-20220106022228-366f3190694e/go.mod h1:c/keGS6bErOzLrFyNgafdDWT6h72v2XQiA/p2R7yghU=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prashantv/gostub v1.0.0 h1:wTzvgO04xSS3gHuz6Vhuo0/kvWelyJxwNS0IRBPAwGY=

--- a/iscsi/iscsi.go
+++ b/iscsi/iscsi.go
@@ -279,7 +279,7 @@ func (c *Connector) Connect() (string, error) {
 	// GetISCSIDevices returns all devices if no paths are given
 	if len(devicePaths) < 1 {
 		c.Devices = []Device{}
-	} else if c.Devices, err = GetISCSIDevices(devicePaths); err != nil {
+	} else if c.Devices, err = GetISCSIDevices(devicePaths, true); err != nil {
 		return "", err
 	}
 
@@ -457,10 +457,10 @@ func (c *Connector) IsMultipathEnabled() bool {
 
 // GetSCSIDevices get SCSI devices from device paths
 // It will returns all SCSI devices if no paths are given
-func GetSCSIDevices(devicePaths []string) ([]Device, error) {
+func GetSCSIDevices(devicePaths []string, strict bool) ([]Device, error) {
 	debug.Printf("Getting info about SCSI devices %s.\n", devicePaths)
 
-	deviceInfo, err := lsblk(devicePaths)
+	deviceInfo, err := lsblk(devicePaths, strict)
 	if err != nil {
 		debug.Printf("An error occured while looking info about SCSI devices: %v", err)
 		return nil, err
@@ -471,8 +471,8 @@ func GetSCSIDevices(devicePaths []string) ([]Device, error) {
 
 // GetISCSIDevices get iSCSI devices from device paths
 // It will returns all iSCSI devices if no paths are given
-func GetISCSIDevices(devicePaths []string) (devices []Device, err error) {
-	scsiDevices, err := GetSCSIDevices(devicePaths)
+func GetISCSIDevices(devicePaths []string, strict bool) (devices []Device, err error) {
+	scsiDevices, err := GetSCSIDevices(devicePaths, strict)
 	if err != nil {
 		return
 	}
@@ -488,21 +488,26 @@ func GetISCSIDevices(devicePaths []string) (devices []Device, err error) {
 }
 
 // lsblk execute the lsblk commands
-func lsblk(devicePaths []string) (*deviceInfo, error) {
+func lsblk(devicePaths []string, strict bool) (*deviceInfo, error) {
 	flags := []string{"-J", "-o", "NAME,HCTL,TYPE,TRAN,SIZE"}
 	command := execCommand("lsblk", append(flags, devicePaths...)...)
 	debug.Println(command.String())
 	out, err := command.Output()
 	if err != nil {
 		if ee, ok := err.(*exec.ExitError); ok {
-			return nil, fmt.Errorf("%s, (%v)", strings.Trim(string(ee.Stderr), "\n"), ee)
+			err = fmt.Errorf("%s, (%w)", strings.Trim(string(ee.Stderr), "\n"), ee)
+			if strict || ee.ExitCode() != 64 { // ignore the error if some devices have been found when not strict
+				return nil, err
+			}
+			debug.Printf("lsblk could find only some devices: %v", err)
+		} else {
+			return nil, err
 		}
-		return nil, err
 	}
 
 	var deviceInfo deviceInfo
-	if err = json.Unmarshal(out, &deviceInfo); err != nil {
-		return nil, err
+	if jsonErr := json.Unmarshal(out, &deviceInfo); jsonErr != nil {
+		return nil, jsonErr
 	}
 
 	return &deviceInfo, nil
@@ -603,13 +608,13 @@ func GetConnectorFromFile(filePath string) (*Connector, error) {
 		devicePaths = append(devicePaths, device.GetPath())
 	}
 
-	if devices, err := GetSCSIDevices([]string{c.MountTargetDevice.GetPath()}); err != nil {
+	if devices, err := GetSCSIDevices([]string{c.MountTargetDevice.GetPath()}, false); err != nil {
 		return nil, err
 	} else {
 		c.MountTargetDevice = &devices[0]
 	}
 
-	if c.Devices, err = GetSCSIDevices(devicePaths); err != nil {
+	if c.Devices, err = GetSCSIDevices(devicePaths, false); err != nil {
 		return nil, err
 	}
 

--- a/iscsi/iscsi.go
+++ b/iscsi/iscsi.go
@@ -224,7 +224,11 @@ func getMultipathDevice(devices []Device) (*Device, error) {
 
 	for _, device := range devices {
 		if len(device.Children) != 1 {
-			return nil, fmt.Errorf("device is not mapped to exactly one multipath device: %v", device.Children)
+			multipathdNotRunning := ""
+			if len(device.Children) == 0 {
+				multipathdNotRunning = " (is multipathd running?)"
+			}
+			return nil, fmt.Errorf("device is not mapped to exactly one multipath device%s: %v", multipathdNotRunning, device.Children)
 		}
 		if multipathDevice != nil && device.Children[0].Name != multipathDevice.Name {
 			return nil, fmt.Errorf("devices don't share a common multipath device: %v", devices)

--- a/iscsi/iscsi.go
+++ b/iscsi/iscsi.go
@@ -148,7 +148,7 @@ func waitForPathToExist(devicePath *string, maxRetries, intervalSeconds int, dev
 
 func waitForPathToExistImpl(devicePath *string, maxRetries, intervalSeconds int, deviceTransport string, osStat statFunc, filepathGlob globFunc) (bool, error) {
 	if devicePath == nil {
-		return false, fmt.Errorf("Unable to check unspecified devicePath")
+		return false, fmt.Errorf("unable to check unspecified devicePath")
 	}
 
 	var err error
@@ -226,7 +226,7 @@ func getMultipathDisk(path string) (string, error) {
 		}
 	}
 	debug.Printf("Couldn't find dm-* path for path: %s, found non dm-* path: %s", path, devicePath)
-	return "", fmt.Errorf("Couldn't find dm-* path for path: %s, found non dm-* path: %s", path, devicePath)
+	return "", fmt.Errorf("couldn't find dm-* path for path: %s, found non dm-* path: %s", path, devicePath)
 }
 
 // Connect attempts to connect a volume to this node using the provided Connector info
@@ -240,7 +240,7 @@ func Connect(c Connector) (string, error) {
 	}
 
 	if c.RetryCount < 0 || c.CheckInterval < 0 {
-		return "", fmt.Errorf("Invalid RetryCount and CheckInterval combination, both must be positive integers. "+
+		return "", fmt.Errorf("invalid RetryCount and CheckInterval combination, both must be positive integers. "+
 			"RetryCount: %d, CheckInterval: %d", c.RetryCount, c.CheckInterval)
 	}
 	var devicePaths []string
@@ -318,7 +318,7 @@ func Connect(c Connector) (string, error) {
 			devicePaths = append(devicePaths, devicePath)
 			continue
 		} else if err != nil {
-			lastErr = fmt.Errorf("Couldn't attach disk, err: %v", err)
+			lastErr = fmt.Errorf("couldn't attach disk, err: %v", err)
 		}
 	}
 

--- a/iscsi/iscsi.go
+++ b/iscsi/iscsi.go
@@ -59,6 +59,8 @@ type Connector struct {
 	CheckInterval   int32 `json:"check_interval"`
 	DoDiscovery     bool  `json:"do_discovery"`
 	DoCHAPDiscovery bool  `json:"do_chap_discovery"`
+	TargetIqn       string `json:"target_iqn"`
+	TargetPortals   []string `json:"target_portals"`
 }
 
 func init() {

--- a/iscsi/iscsi.go
+++ b/iscsi/iscsi.go
@@ -77,7 +77,7 @@ func EnableDebugLogging(writer io.Writer) {
 
 // parseSession takes the raw stdout from the iscsiadm -m session command and encodes it into an iscsi session type
 func parseSessions(lines string) []iscsiSession {
-	entries := strings.Split(strings.TrimSpace(string(lines)), "\n")
+	entries := strings.Split(strings.TrimSpace(lines), "\n")
 	r := strings.NewReplacer("[", "",
 		"]", "")
 
@@ -458,7 +458,7 @@ func GetConnectorFromFile(filePath string) (*Connector, error) {
 
 	}
 	data := Connector{}
-	err = json.Unmarshal([]byte(f), &data)
+	err = json.Unmarshal(f, &data)
 	if err != nil {
 		return &Connector{}, err
 	}

--- a/iscsi/iscsi.go
+++ b/iscsi/iscsi.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -15,12 +14,13 @@ import (
 	"strings"
 	"syscall"
 	"time"
+
+	"k8s.io/klog/v2"
 )
 
 const defaultPort = "3260"
 
 var (
-	debug              *log.Logger
 	execCommand        = exec.Command
 	execCommandContext = exec.CommandContext
 	execWithTimeout    = ExecWithTimeout
@@ -78,15 +78,17 @@ type Connector struct {
 	DoCHAPDiscovery bool `json:"do_chap_discovery"`
 }
 
+var version string = "1.0.0"
+
 func init() {
-	// by default we don't log anything, EnableDebugLogging() can turn on some tracing
-	debug = log.New(ioutil.Discard, "", 0)
+	// By default we produce info and error log entries which can be redirected using EnableDebugLogging()
+	klog.InfoS("[] csi-lib-iscsi", "version", version)
 }
 
-// EnableDebugLogging provides a mechanism to turn on debug logging for this package
-// output is written to the provided io.Writer
+// EnableDebugLogging provides a mechanism to allow a caller to set their own io.Writer
 func EnableDebugLogging(writer io.Writer) {
-	debug = log.New(writer, "DEBUG: ", log.Ldate|log.Ltime|log.Lshortfile)
+	klog.InfoS("Enable a caller's io.Writer")
+	klog.SetOutput(writer)
 }
 
 // parseSession takes the raw stdout from the iscsiadm -m session command and encodes it into an iSCSI session type
@@ -166,7 +168,7 @@ func waitForPathToExist(devicePath *string, maxRetries, intervalSeconds uint, de
 
 	for i := uint(0); i <= maxRetries; i++ {
 		if i != 0 {
-			debug.Printf("Device path %q doesn't exists yet, retrying in %d seconds (%d/%d)", *devicePath, intervalSeconds, i, maxRetries)
+			klog.InfoS("Device path doesn't exists yet, retrying", "device", *devicePath, "seconds", intervalSeconds, "retries", 1, "max", maxRetries)
 			sleep(time.Second * time.Duration(intervalSeconds))
 		}
 
@@ -186,10 +188,10 @@ func pathExists(devicePath *string, deviceTransport string) error {
 		_, err := osStat(*devicePath)
 		if err != nil {
 			if !os.IsNotExist(err) {
-				debug.Printf("Error attempting to stat device: %s", err.Error())
+				klog.ErrorS(err, "Error attempting to stat device")
 				return err
 			}
-			debug.Printf("Device not found for: %s", *devicePath)
+			klog.InfoS("Device not found", "device", *devicePath)
 			return err
 		}
 	} else {
@@ -214,18 +216,18 @@ func pathExists(devicePath *string, deviceTransport string) error {
 func getMultipathDevice(devices []Device) (*Device, error) {
 	var multipathDevice *Device
 
+	// This routine relies on output from lsblk, and older versions did not produce the desired outcome
+	// of a child row, followed by a parent row. This routine now just takes the first parent found.
 	for _, device := range devices {
+		klog.InfoS("find multipath device", "device", device)
 		if len(device.Children) != 1 {
-			multipathdNotRunning := ""
-			if len(device.Children) == 0 {
-				multipathdNotRunning = " (is multipathd running?)"
-			}
-			return nil, fmt.Errorf("device is not mapped to exactly one multipath device%s: %v", multipathdNotRunning, device.Children)
+			klog.InfoS("WARNING: children != 1", "name", device.Name)
 		}
-		if multipathDevice != nil && device.Children[0].Name != multipathDevice.Name {
-			return nil, fmt.Errorf("devices don't share a common multipath device: %v", devices)
+		if len(device.Children) == 1 {
+			multipathDevice = &device.Children[0]
+			klog.InfoS("SET: multipath device", "name", multipathDevice.Name)
+			break
 		}
-		multipathDevice = &device.Children[0]
 	}
 
 	if multipathDevice == nil {
@@ -239,7 +241,7 @@ func getMultipathDevice(devices []Device) (*Device, error) {
 	return multipathDevice, nil
 }
 
-// Connect is for backward-compatiblity with c.Connect()
+// Connect is for backward-compatibility with c.Connect()
 func Connect(c Connector) (string, error) {
 	return c.Connect()
 }
@@ -272,7 +274,7 @@ func (c *Connector) Connect() (string, error) {
 		if err != nil {
 			lastErr = err
 		} else {
-			debug.Printf("Appending device path: %s", devicePath)
+			klog.InfoS("Appending device path", "device", devicePath)
 			devicePaths = append(devicePaths, devicePath)
 		}
 	}
@@ -285,6 +287,7 @@ func (c *Connector) Connect() (string, error) {
 	}
 
 	if len(c.Devices) < 1 {
+		klog.ErrorS(lastErr, "failed to find device path", "length", len(c.Devices))
 		iscsiCmd([]string{"-m", "iface", "-I", iFace, "-o", "delete"}...)
 		return "", fmt.Errorf("failed to find device path: %s, last error seen: %v", devicePaths, lastErr)
 	}
@@ -292,7 +295,7 @@ func (c *Connector) Connect() (string, error) {
 	mountTargetDevice, err := c.getMountTargetDevice()
 	c.MountTargetDevice = mountTargetDevice
 	if err != nil {
-		debug.Printf("Connect failed: %v", err)
+		klog.ErrorS(err, "Connect failed")
 		err := RemoveSCSIDevices(c.Devices...)
 		if err != nil {
 			return "", err
@@ -312,7 +315,7 @@ func (c *Connector) Connect() (string, error) {
 }
 
 func (c *Connector) connectTarget(targetIqn string, target string, iFace string, iscsiTransport string) (string, error) {
-	debug.Printf("Process targetIqn: %s, portal: %s\n", targetIqn, target)
+	klog.InfoS("Connect target", "iqn", targetIqn, "portal", target)
 	targetParts := strings.Split(target, ":")
 	targetPortal := targetParts[0]
 	targetPort := defaultPort
@@ -323,9 +326,9 @@ func (c *Connector) connectTarget(targetIqn string, target string, iFace string,
 	// Rescan sessions to discover newly mapped LUNs. Do not specify the interface when rescanning
 	// to avoid establishing additional sessions to the same target.
 	if _, err := iscsiCmd(append(baseArgs, []string{"-R"}...)...); err != nil {
-		debug.Printf("Failed to rescan session, err: %v", err)
+		klog.ErrorS(err, "Failed to rescan session")
 		if os.IsTimeout(err) {
-			debug.Printf("iscsiadm timeouted, logging out")
+			klog.InfoS("iscsiadm timed out, logging out")
 			cmd := execCommand("iscsiadm", append(baseArgs, []string{"-u"}...)...)
 			out, err := cmd.CombinedOutput()
 			if err != nil {
@@ -344,7 +347,7 @@ func (c *Connector) connectTarget(targetIqn string, target string, iFace string,
 
 	exists, _ := sessionExists(portal, targetIqn)
 	if exists {
-		debug.Printf("Session already exists, checking if device path %q exists", devicePath)
+		klog.InfoS("Session already exists, checking if device path exists", "device", devicePath)
 		if err := waitForPathToExist(&devicePath, c.RetryCount, c.CheckInterval, iscsiTransport); err != nil {
 			return "", err
 		}
@@ -358,11 +361,11 @@ func (c *Connector) connectTarget(targetIqn string, target string, iFace string,
 	// perform the login
 	err := Login(targetIqn, portal)
 	if err != nil {
-		debug.Printf("Failed to login: %v", err)
+		klog.ErrorS(err, "Failed to login")
 		return "", err
 	}
 
-	debug.Printf("Waiting for device path %q to exist", devicePath)
+	klog.InfoS("Waiting for device path to exist", "device", devicePath)
 	if err := waitForPathToExist(&devicePath, c.RetryCount, c.CheckInterval, iscsiTransport); err != nil {
 		return "", err
 	}
@@ -374,7 +377,7 @@ func (c *Connector) discoverTarget(targetIqn string, iFace string, portal string
 	if c.DoDiscovery {
 		// build discoverydb and discover iscsi target
 		if err := Discoverydb(portal, iFace, c.DiscoverySecrets, c.DoCHAPDiscovery); err != nil {
-			debug.Printf("Error in discovery of the target: %s\n", err.Error())
+			klog.ErrorS(err, "Error in discovery of the target")
 			return err
 		}
 	}
@@ -383,7 +386,7 @@ func (c *Connector) discoverTarget(targetIqn string, iFace string, portal string
 		// Make sure we don't log the secrets
 		err := CreateDBEntry(targetIqn, portal, iFace, c.DiscoverySecrets, c.SessionSecrets)
 		if err != nil {
-			debug.Printf("Error creating db entry: %s\n", err.Error())
+			klog.ErrorS(err, "Error creating db entry")
 			return err
 		}
 	}
@@ -435,7 +438,7 @@ func (c *Connector) DisconnectVolume() error {
 			return fmt.Errorf("multipath is inconsistent: %v", err)
 		}
 
-		debug.Printf("Removing multipath device in path %s.\n", c.MountTargetDevice.GetPath())
+		klog.InfoS("Removing multipath device in path", "device", c.MountTargetDevice.GetPath())
 		err := FlushMultipathDevice(c.MountTargetDevice)
 		if err != nil {
 			return err
@@ -445,13 +448,13 @@ func (c *Connector) DisconnectVolume() error {
 		}
 	} else {
 		devicePath := c.MountTargetDevice.GetPath()
-		debug.Printf("Removing normal device in path %s.\n", devicePath)
+		klog.InfoS("Removing normal device in path", "device", devicePath)
 		if err := RemoveSCSIDevices(*c.MountTargetDevice); err != nil {
 			return err
 		}
 	}
 
-	debug.Printf("Finished disconnecting volume.\n")
+	klog.InfoS("Finished disconnecting volume.")
 	return nil
 }
 
@@ -460,10 +463,10 @@ func (c *Connector) getMountTargetDevice() (*Device, error) {
 	if len(c.Devices) > 1 {
 		multipathDevice, err := getMultipathDevice(c.Devices)
 		if err != nil {
-			debug.Printf("mount target is not a multipath device: %v", err)
+			klog.ErrorS(err, "Mount target is not a multipath device")
 			return nil, err
 		}
-		debug.Printf("mount target is a multipath device")
+		klog.InfoS("Mount target is a multipath device")
 		return multipathDevice, nil
 	}
 
@@ -482,11 +485,11 @@ func (c *Connector) IsMultipathEnabled() bool {
 // GetSCSIDevices get SCSI devices from device paths
 // It will returns all SCSI devices if no paths are given
 func GetSCSIDevices(devicePaths []string, strict bool) ([]Device, error) {
-	debug.Printf("Getting info about SCSI devices %s.\n", devicePaths)
+	klog.InfoS("Getting info about SCSI devices", "devices", devicePaths)
 
 	deviceInfo, err := lsblk(devicePaths, strict)
 	if err != nil {
-		debug.Printf("An error occured while looking info about SCSI devices: %v", err)
+		klog.ErrorS(err, "An error occurred while looking info about SCSI devices")
 		return nil, err
 	}
 
@@ -504,6 +507,7 @@ func GetISCSIDevices(devicePaths []string, strict bool) (devices []Device, err e
 	for i := range scsiDevices {
 		device := &scsiDevices[i]
 		if device.Transport == "iscsi" {
+			klog.InfoS("append iscsi device", "device", *device)
 			devices = append(devices, *device)
 		}
 	}
@@ -515,15 +519,16 @@ func GetISCSIDevices(devicePaths []string, strict bool) (devices []Device, err e
 func lsblk(devicePaths []string, strict bool) (deviceInfo, error) {
 	flags := []string{"-rn", "-o", "NAME,KNAME,PKNAME,HCTL,TYPE,TRAN,SIZE"}
 	command := execCommand("lsblk", append(flags, devicePaths...)...)
-	debug.Println(command.String())
+	klog.InfoS("lsblk", "command", command.String())
 	out, err := command.Output()
+	klog.InfoS("lsblk", "output", out, "error", "err")
 	if err != nil {
 		if ee, ok := err.(*exec.ExitError); ok {
 			err = fmt.Errorf("%s, (%w)", strings.Trim(string(ee.Stderr), "\n"), ee)
 			if strict || ee.ExitCode() != 64 { // ignore the error if some devices have been found when not strict
 				return nil, err
 			}
-			debug.Printf("Could find only some devices: %v", err)
+			klog.ErrorS(err, "Could find only some devices")
 		} else {
 			return nil, err
 		}
@@ -537,7 +542,9 @@ func lsblk(devicePaths []string, strict bool) (deviceInfo, error) {
 	lines := strings.Split(strings.Trim(string(out), "\n"), "\n")
 	for _, line := range lines {
 		columns := strings.Split(line, " ")
+		klog.InfoS("parse devices", "columns", columns)
 		if len(columns) < 5 {
+			klog.InfoS("invalid output from lsblk", "line", line)
 			return nil, fmt.Errorf("invalid output from lsblk: %s", line)
 		}
 		device := &Device{
@@ -547,6 +554,7 @@ func lsblk(devicePaths []string, strict bool) (deviceInfo, error) {
 			Transport: columns[5],
 			Size:      columns[6],
 		}
+		klog.InfoS("append device", "column1", columns[1], "column2", columns[2], "device", device)
 		devices = append(devices, device)
 		pkNames = append(pkNames, columns[2])
 		devicesMap[columns[1]] = device
@@ -565,6 +573,7 @@ func lsblk(devicePaths []string, strict bool) (deviceInfo, error) {
 		if parent.Children == nil {
 			parent.Children = []Device{}
 		}
+		klog.InfoS("append child", "pkName", pkName, "device", *device)
 		parent.Children = append(devicesMap[pkName].Children, *device)
 	}
 
@@ -572,6 +581,7 @@ func lsblk(devicePaths []string, strict bool) (deviceInfo, error) {
 	var deviceInfo deviceInfo
 	for i, device := range devices {
 		if pkNames[i] == "" {
+			klog.InfoS("append device info", "pkName", pkNames[i], "device", *device)
 			deviceInfo = append(deviceInfo, *device)
 		}
 	}
@@ -582,17 +592,17 @@ func lsblk(devicePaths []string, strict bool) (deviceInfo, error) {
 // writeInSCSIDeviceFile write into special devices files to change devices state
 func writeInSCSIDeviceFile(hctl string, file string, content string) error {
 	filename := filepath.Join("/sys/class/scsi_device", hctl, "device", file)
-	debug.Printf("Write %q in %q.\n", content, filename)
+	klog.InfoS("Write to SCSI device", "content", content, "filename", filename)
 
 	f, err := osOpenFile(filename, os.O_TRUNC|os.O_WRONLY, 0200)
 	if err != nil {
-		debug.Printf("Error while opening file %v: %v\n", filename, err)
+		klog.ErrorS(err, "Error attempting to open file", "filename", filename)
 		return err
 	}
 
 	defer f.Close()
 	if _, err := f.WriteString(content); err != nil {
-		debug.Printf("Error while writing to file %v: %v", filename, err)
+		klog.ErrorS(err, "Error attempting to write to file", "filename", filename)
 		return err
 	}
 
@@ -601,22 +611,22 @@ func writeInSCSIDeviceFile(hctl string, file string, content string) error {
 
 // RemoveSCSIDevices removes SCSI device(s) from a Linux host.
 func RemoveSCSIDevices(devices ...Device) error {
-	debug.Printf("Removing SCSI devices %v.\n", devices)
+	klog.InfoS("Removing SCSI devices", "devices", devices)
 
 	var errs []error
 	for _, device := range devices {
-		debug.Printf("Flush SCSI device %v.\n", device.Name)
+		klog.InfoS("Flush SCSI device", "device", device.Name)
 		if err := device.Exists(); err == nil {
 			out, err := execCommand("blockdev", "--flushbufs", device.GetPath()).CombinedOutput()
 			if err != nil {
-				debug.Printf("Command 'blockdev --flushbufs %s' did not succeed to flush the device: %v\n", device.GetPath(), err)
+				klog.ErrorS(err, "Command 'blockdev --flushbufs <device>' did not succeed to flush the device", "device", device.GetPath())
 				return errors.New(string(out))
 			}
 		} else if !os.IsNotExist(err) {
 			return err
 		}
 
-		debug.Printf("Put SCSI device %q offline.\n", device.Name)
+		klog.InfoS("Put SCSI device offline", "device", device.Name)
 		err := device.Shutdown()
 		if err != nil {
 			if !os.IsNotExist(err) { // Ignore device already removed
@@ -625,7 +635,7 @@ func RemoveSCSIDevices(devices ...Device) error {
 			continue
 		}
 
-		debug.Printf("Delete SCSI device %q.\n", device.Name)
+		klog.InfoS("Delete SCSI device", "device", device.Name)
 		err = device.Delete()
 		if err != nil {
 			if !os.IsNotExist(err) { // Ignore device already removed
@@ -638,7 +648,7 @@ func RemoveSCSIDevices(devices ...Device) error {
 	if len(errs) > 0 {
 		return errs[0]
 	}
-	debug.Println("Finished removing SCSI devices.")
+	klog.InfoS("Finished removing SCSI devices.")
 	return nil
 }
 

--- a/iscsi/iscsi.go
+++ b/iscsi/iscsi.go
@@ -318,6 +318,14 @@ func (c *Connector) connectTarget(target *TargetInfo, iFace string, iscsiTranspo
 	// to avoid establishing additional sessions to the same target.
 	if _, err := iscsiCmd(append(baseArgs, []string{"-R"}...)...); err != nil {
 		debug.Printf("Failed to rescan session, err: %v", err)
+		if os.IsTimeout(err) {
+			debug.Printf("iscsiadm timeouted, logging out")
+			cmd := execCommand("iscsiadm", append(baseArgs, []string{"-u"}...)...)
+			out, err := cmd.CombinedOutput()
+			if err != nil {
+				return "", fmt.Errorf("could not logout from target: %s", out)
+			}
+		}
 	}
 
 	// create our devicePath that we'll be looking for based on the transport being used

--- a/iscsi/iscsi.go
+++ b/iscsi/iscsi.go
@@ -567,7 +567,7 @@ func RemoveSCSIDevices(devices ...Device) error {
 	if len(errs) > 0 {
 		return errs[0]
 	}
-	debug.Println("Finshed removing SCSI devices.")
+	debug.Println("Finished removing SCSI devices.")
 	return nil
 }
 

--- a/iscsi/iscsi.go
+++ b/iscsi/iscsi.go
@@ -433,7 +433,7 @@ func (c *Connector) DisconnectVolume() error {
 
 // getMountTargetDevice returns the device to be mounted among the configured devices
 func (c *Connector) getMountTargetDevice() (*Device, error) {
-	if c.IsMultipathEnabled() {
+	if len(c.Devices) > 1 {
 		multipathDevice, err := getMultipathDevice(c.Devices)
 		if err != nil {
 			debug.Printf("mount target is not a multipath device: %v", err)
@@ -452,7 +452,7 @@ func (c *Connector) getMountTargetDevice() (*Device, error) {
 
 // IsMultipathEnabled check if multipath is enabled on devices handled by this connector
 func (c *Connector) IsMultipathEnabled() bool {
-	return len(c.Devices) > 1
+	return c.MountTargetDevice.Type == "mpath"
 }
 
 // GetSCSIDevices get SCSI devices from device paths
@@ -499,7 +499,7 @@ func lsblk(devicePaths []string, strict bool) (*deviceInfo, error) {
 			if strict || ee.ExitCode() != 64 { // ignore the error if some devices have been found when not strict
 				return nil, err
 			}
-			debug.Printf("lsblk could find only some devices: %v", err)
+			debug.Printf("Could find only some devices: %v", err)
 		} else {
 			return nil, err
 		}

--- a/iscsi/iscsi.go
+++ b/iscsi/iscsi.go
@@ -293,7 +293,10 @@ func (c *Connector) Connect() (string, error) {
 	c.MountTargetDevice = mountTargetDevice
 	if err != nil {
 		debug.Printf("Connect failed: %v", err)
-		RemoveSCSIDevices(c.Devices...)
+		err := RemoveSCSIDevices(c.Devices...)
+		if err != nil {
+			return "", err
+		}
 		c.MountTargetDevice = nil
 		c.Devices = []Device{}
 		return "", err
@@ -392,7 +395,10 @@ func (c *Connector) discoverTarget(targetIqn string, iFace string, portal string
 func Disconnect(targetIqn string, targets []string) {
 	for _, target := range targets {
 		targetPortal := strings.Split(target, ":")[0]
-		Logout(targetIqn, targetPortal)
+		err := Logout(targetIqn, targetPortal)
+		if err != nil {
+			return
+		}
 	}
 
 	deleted := map[string]bool{}
@@ -400,7 +406,10 @@ func Disconnect(targetIqn string, targets []string) {
 		return
 	}
 	deleted[targetIqn] = true
-	DeleteDBEntry(targetIqn)
+	err := DeleteDBEntry(targetIqn)
+	if err != nil {
+		return
+	}
 }
 
 // Disconnect performs a disconnect operation from an appliance.
@@ -669,7 +678,9 @@ func GetConnectorFromFile(filePath string) (*Connector, error) {
 	for _, device := range c.Devices {
 		devicePaths = append(devicePaths, device.GetPath())
 	}
-
+	if c.MountTargetDevice == nil {
+		return nil, fmt.Errorf("mountTargetDevice in the connector is nil")
+	}
 	if devices, err := GetSCSIDevices([]string{c.MountTargetDevice.GetPath()}, false); err != nil {
 		return nil, err
 	} else {

--- a/iscsi/iscsi.go
+++ b/iscsi/iscsi.go
@@ -20,13 +20,14 @@ import (
 const defaultPort = "3260"
 
 var (
-	debug           *log.Logger
-	execCommand     = exec.Command
-	execWithTimeout = ExecWithTimeout
+	debug              *log.Logger
+	execCommand        = exec.Command
+	execCommandContext = exec.CommandContext
+	execWithTimeout    = ExecWithTimeout
+	osStat             = os.Stat
+	filepathGlob       = filepath.Glob
+	osOpenFile         = os.OpenFile
 )
-
-type statFunc func(string) (os.FileInfo, error)
-type globFunc func(string) ([]string, error)
 
 // iscsiSession contains information avout an iSCSI session
 type iscsiSession struct {
@@ -161,10 +162,6 @@ func getCurrentSessions() ([]iscsiSession, error) {
 
 // waitForPathToExist wait for a file at a path to exists on disk
 func waitForPathToExist(devicePath *string, maxRetries, intervalSeconds uint, deviceTransport string) error {
-	return waitForPathToExistImpl(devicePath, maxRetries, intervalSeconds, deviceTransport, os.Stat, filepath.Glob)
-}
-
-func waitForPathToExistImpl(devicePath *string, maxRetries, intervalSeconds uint, deviceTransport string, osStat statFunc, filepathGlob globFunc) error {
 	if devicePath == nil {
 		return fmt.Errorf("unable to check unspecified devicePath")
 	}
@@ -175,7 +172,7 @@ func waitForPathToExistImpl(devicePath *string, maxRetries, intervalSeconds uint
 			time.Sleep(time.Second * time.Duration(intervalSeconds))
 		}
 
-		if err := pathExistsImpl(devicePath, deviceTransport, osStat, filepathGlob); err == nil {
+		if err := pathExists(devicePath, deviceTransport); err == nil {
 			return nil
 		} else if !os.IsNotExist(err) {
 			return err
@@ -187,10 +184,6 @@ func waitForPathToExistImpl(devicePath *string, maxRetries, intervalSeconds uint
 
 // pathExists checks if a file at a path exists on disk
 func pathExists(devicePath *string, deviceTransport string) error {
-	return pathExistsImpl(devicePath, deviceTransport, os.Stat, filepath.Glob)
-}
-
-func pathExistsImpl(devicePath *string, deviceTransport string, osStat statFunc, filepathGlob globFunc) error {
 	if deviceTransport == "tcp" {
 		_, err := osStat(*devicePath)
 		if err != nil {
@@ -423,11 +416,7 @@ func (c *Connector) DisconnectVolume() error {
 	} else {
 		devicePath := c.MountTargetDevice.GetPath()
 		debug.Printf("Removing normal device in path %s.\n", devicePath)
-		device, err := GetISCSIDevice(devicePath)
-		if err != nil {
-			return err
-		}
-		if err = RemoveSCSIDevices(*device); err != nil {
+		if err := RemoveSCSIDevices(*c.MountTargetDevice); err != nil {
 			return err
 		}
 	}
@@ -458,18 +447,6 @@ func (c *Connector) getMountTargetDevice() (*Device, error) {
 // IsMultipathEnabled check if multipath is enabled on devices handled by this connector
 func (c *Connector) IsMultipathEnabled() bool {
 	return len(c.Devices) > 1
-}
-
-// GetISCSIDevice get an SCSI device from a device name
-func GetISCSIDevice(deviceName string) (*Device, error) {
-	iscsiDevices, err := GetISCSIDevices([]string{deviceName})
-	if err != nil {
-		return nil, err
-	}
-	if len(iscsiDevices) == 0 {
-		return nil, fmt.Errorf("device %q not found", deviceName)
-	}
-	return &iscsiDevices[0], nil
 }
 
 // GetSCSIDevices get SCSI devices from device paths
@@ -512,7 +489,7 @@ func GetISCSIDevices(devicePaths []string) (devices []Device, err error) {
 
 // lsblk execute the lsblk commands
 func lsblk(flags string, devicePaths []string) ([]byte, error) {
-	out, err := exec.Command("lsblk", append([]string{flags}, devicePaths...)...).CombinedOutput()
+	out, err := execCommand("lsblk", append([]string{flags}, devicePaths...)...).CombinedOutput()
 	debug.Printf("lsblk %s %s", flags, strings.Join(devicePaths, " "))
 	if err != nil {
 		return nil, fmt.Errorf("lsblk: %s", string(out))
@@ -526,7 +503,7 @@ func writeInSCSIDeviceFile(hctl string, file string, content string) error {
 	filename := filepath.Join("/sys/class/scsi_device", hctl, "device", file)
 	debug.Printf("Write %q in %q.\n", content, filename)
 
-	f, err := os.OpenFile(filename, os.O_TRUNC|os.O_WRONLY, 0200)
+	f, err := osOpenFile(filename, os.O_TRUNC|os.O_WRONLY, 0200)
 	if err != nil {
 		debug.Printf("Error while opening file %v: %v\n", filename, err)
 		return err
@@ -549,7 +526,7 @@ func RemoveSCSIDevices(devices ...Device) error {
 	for _, device := range devices {
 		debug.Printf("Flush SCSI device %v.\n", device.Name)
 		if err := device.Exists(); err == nil {
-			out, err := exec.Command("blockdev", "--flushbufs", device.GetPath()).CombinedOutput()
+			out, err := execCommand("blockdev", "--flushbufs", device.GetPath()).CombinedOutput()
 			if err != nil {
 				debug.Printf("Command 'blockdev --flushbufs %s' did not succeed to flush the device: %v\n", device.GetPath(), err)
 				return errors.New(string(out))
@@ -617,7 +594,7 @@ func GetConnectorFromFile(filePath string) (*Connector, error) {
 
 // Exists check if the device exists at its path and returns an error otherwise
 func (d *Device) Exists() error {
-	_, err := os.Stat(d.GetPath())
+	_, err := osStat(d.GetPath())
 	return err
 }
 

--- a/iscsi/iscsi.go
+++ b/iscsi/iscsi.go
@@ -376,7 +376,7 @@ func DisconnectVolume(c Connector) error {
 		if err != nil {
 			return err
 		}
-		err := FlushMultipathDevice(c.DevicePath)
+		err = FlushMultipathDevice(c.DevicePath)
 		if err != nil {
 			return err
 		}

--- a/iscsi/iscsi_test.go
+++ b/iscsi/iscsi_test.go
@@ -248,7 +248,7 @@ func Test_extractTransportName(t *testing.T) {
 
 func Test_sessionExists(t *testing.T) {
 	fakeOutput := "tcp: [4] 192.168.1.107:3260,1 iqn.2010-10.org.openstack:volume-eb393993-73d0-4e39-9ef4-b5841e244ced (non-flash)\n"
-	defer gostub.Stub(&execCommand, makeFakeExecCommand(0, fakeOutput)).Reset()
+	defer gostub.Stub(&execWithTimeout, makeFakeExecWithTimeout(false, []byte(fakeOutput), nil)).Reset()
 
 	type args struct {
 		tgtPortal string

--- a/iscsi/iscsi_test.go
+++ b/iscsi/iscsi_test.go
@@ -668,7 +668,8 @@ func TestConnectorPersistance(t *testing.T) {
 	}
 	c := Connector{
 		VolumeName:        "fake volume name",
-		Targets:           []TargetInfo{},
+		TargetIqn:         "fake target iqn",
+		TargetPortals:     []string{},
 		Lun:               42,
 		AuthType:          "fake auth type",
 		DiscoverySecrets:  secret,

--- a/iscsi/iscsi_test.go
+++ b/iscsi/iscsi_test.go
@@ -272,7 +272,6 @@ func Test_sessionExists(t *testing.T) {
 }
 
 func Test_DisconnectNormalVolume(t *testing.T) {
-
 	tmpDir, err := ioutil.TempDir("", "")
 	if err != nil {
 		t.Errorf("can not create temp directory: %v", err)

--- a/iscsi/iscsi_test.go
+++ b/iscsi/iscsi_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/prashantv/gostub"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/klog/v2"
+	"k8s.io/klog/v2/ktesting"
 )
 
 type testWriter struct {
@@ -418,12 +419,13 @@ func Test_EnableDebugLogging(t *testing.T) {
 	assert := assert.New(t)
 	data := []byte{}
 	writer := testWriter{data: &data}
-	EnableDebugLogging(writer)
+	klog.SetOutput(writer)
 
 	assert.Equal("", string(data))
 	assert.Len(strings.Split(string(data), "\n"), 1)
 
-	klog.InfoS("testing debug logs")
+	logger, _ := ktesting.NewTestContext(t)
+	logger.Info("testing debug logs")
 	assert.Contains(string(data), "testing debug logs")
 	assert.Len(strings.Split(string(data), "\n"), 2)
 }

--- a/iscsi/iscsi_test.go
+++ b/iscsi/iscsi_test.go
@@ -89,6 +89,7 @@ var testExecWithTimeoutError error
 var mockedExitStatus = 0
 var mockedStdout string
 
+var sysBlockPath = "/sys/block"
 var normalDevice = "sda"
 var multipathDevice = "dm-1"
 var slaves = []string{"sdb", "sdc"}

--- a/iscsi/iscsi_test.go
+++ b/iscsi/iscsi_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/prashantv/gostub"
 	"github.com/stretchr/testify/assert"
+	"k8s.io/klog/v2"
 )
 
 type testWriter struct {
@@ -422,7 +423,7 @@ func Test_EnableDebugLogging(t *testing.T) {
 	assert.Equal("", string(data))
 	assert.Len(strings.Split(string(data), "\n"), 1)
 
-	debug.Print("testing debug logs")
+	klog.InfoS("testing debug logs")
 	assert.Contains(string(data), "testing debug logs")
 	assert.Len(strings.Split(string(data), "\n"), 2)
 }

--- a/iscsi/iscsiadm.go
+++ b/iscsi/iscsiadm.go
@@ -65,12 +65,18 @@ func CreateDBEntry(tgtIQN, portal, iFace string, discoverySecrets, sessionSecret
 
 	if discoverySecrets.SecretsType == "chap" {
 		debug.Printf("Setting CHAP Discovery...")
-		createCHAPEntries(baseArgs, discoverySecrets, true)
+		err := createCHAPEntries(baseArgs, discoverySecrets, true)
+		if err != nil {
+			return err
+		}
 	}
 
 	if sessionSecrets.SecretsType == "chap" {
 		debug.Printf("Setting CHAP Session...")
-		createCHAPEntries(baseArgs, sessionSecrets, false)
+		err := createCHAPEntries(baseArgs, sessionSecrets, false)
+		if err != nil {
+			return err
+		}
 	}
 
 	return err

--- a/iscsi/iscsiadm.go
+++ b/iscsi/iscsiadm.go
@@ -36,6 +36,7 @@ func (e *CmdError) Error() string {
 
 func iscsiCmd(args ...string) (string, error) {
 	cmd := execCommand("iscsiadm", args...)
+	debug.Printf("Run iscsiadm command: %s", strings.Join(append([]string{"iscsiadm"}, args...), " "))
 	var stdout bytes.Buffer
 	var iscsiadmError error
 	cmd.Stdout = &stdout
@@ -91,7 +92,7 @@ func ShowInterface(iface string) (string, error) {
 func CreateDBEntry(tgtIQN, portal, iFace string, discoverySecrets, sessionSecrets Secrets) error {
 	debug.Println("Begin CreateDBEntry...")
 	baseArgs := []string{"-m", "node", "-T", tgtIQN, "-p", portal}
-	_, err := iscsiCmd(append(baseArgs, []string{"-I", iFace, "-o", "new"}...)...)
+	_, err := iscsiCmd(append(baseArgs, "-I", iFace, "-o", "new")...)
 	if err != nil {
 		return err
 	}

--- a/iscsi/iscsiadm.go
+++ b/iscsi/iscsiadm.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 	"time"
+
+	"k8s.io/klog/v2"
 )
 
 // Secrets provides optional iscsi security credentials (CHAP settings)
@@ -23,7 +25,7 @@ type Secrets struct {
 func iscsiCmd(args ...string) (string, error) {
 	stdout, err := execWithTimeout("iscsiadm", args, time.Second*3)
 
-	debug.Printf("Run iscsiadm command: %s", strings.Join(append([]string{"iscsiadm"}, args...), " "))
+	klog.InfoS("Run iscsiadm", "command", strings.Join(append([]string{"iscsiadm"}, args...), " "))
 	iscsiadmDebug(string(stdout), err)
 
 	return string(stdout), err
@@ -31,9 +33,9 @@ func iscsiCmd(args ...string) (string, error) {
 
 func iscsiadmDebug(output string, cmdError error) {
 	debugOutput := strings.Replace(output, "\n", "\\n", -1)
-	debug.Printf("Output of iscsiadm command: {output: %s}", debugOutput)
+	klog.InfoS("Output of iscsiadm command", "output", debugOutput)
 	if cmdError != nil {
-		debug.Printf("Error message returned from iscsiadm command: %s", cmdError.Error())
+		klog.ErrorS(cmdError, "Error message returned from iscsiadm command")
 	}
 }
 
@@ -41,7 +43,7 @@ func iscsiadmDebug(output string, cmdError error) {
 /// along with the raw output in Response.StdOut we add the convenience of
 // returning a list of entries found
 func ListInterfaces() ([]string, error) {
-	debug.Println("Begin ListInterface...")
+	klog.InfoS("Begin ListInterface...")
 	out, err := iscsiCmd("-m", "iface", "-o", "show")
 	return strings.Split(out, "\n"), err
 }
@@ -49,14 +51,14 @@ func ListInterfaces() ([]string, error) {
 // ShowInterface retrieves the details for the specified iscsi interface
 // caller should inspect r.Err and use r.StdOut for interface details
 func ShowInterface(iface string) (string, error) {
-	debug.Println("Begin ShowInterface...")
+	klog.InfoS("Begin ShowInterface...")
 	out, err := iscsiCmd("-m", "iface", "-o", "show", "-I", iface)
 	return out, err
 }
 
 // CreateDBEntry sets up a node entry for the specified tgt in the nodes iscsi nodes db
 func CreateDBEntry(tgtIQN, portal, iFace string, discoverySecrets, sessionSecrets Secrets) error {
-	debug.Println("Begin CreateDBEntry...")
+	klog.InfoS("Begin CreateDBEntry...")
 	baseArgs := []string{"-m", "node", "-T", tgtIQN, "-p", portal}
 	_, err := iscsiCmd(append(baseArgs, "-I", iFace, "-o", "new")...)
 	if err != nil {
@@ -64,7 +66,7 @@ func CreateDBEntry(tgtIQN, portal, iFace string, discoverySecrets, sessionSecret
 	}
 
 	if discoverySecrets.SecretsType == "chap" {
-		debug.Printf("Setting CHAP Discovery...")
+		klog.InfoS("Setting CHAP Discovery...")
 		err := createCHAPEntries(baseArgs, discoverySecrets, true)
 		if err != nil {
 			return err
@@ -72,7 +74,7 @@ func CreateDBEntry(tgtIQN, portal, iFace string, discoverySecrets, sessionSecret
 	}
 
 	if sessionSecrets.SecretsType == "chap" {
-		debug.Printf("Setting CHAP Session...")
+		klog.InfoS("Setting CHAP Session...")
 		err := createCHAPEntries(baseArgs, sessionSecrets, false)
 		if err != nil {
 			return err
@@ -85,7 +87,7 @@ func CreateDBEntry(tgtIQN, portal, iFace string, discoverySecrets, sessionSecret
 
 // Discoverydb discovers the iscsi target
 func Discoverydb(tp, iface string, discoverySecrets Secrets, chapDiscovery bool) error {
-	debug.Println("Begin Discoverydb...")
+	klog.InfoS("Begin Discoverydb...")
 	baseArgs := []string{"-m", "discoverydb", "-t", "sendtargets", "-p", tp, "-I", iface}
 	out, err := iscsiCmd(append(baseArgs, []string{"-o", "new"}...)...)
 	if err != nil {
@@ -109,7 +111,7 @@ func Discoverydb(tp, iface string, discoverySecrets Secrets, chapDiscovery bool)
 
 func createCHAPEntries(baseArgs []string, secrets Secrets, discovery bool) error {
 	args := []string{}
-	debug.Printf("Begin createCHAPEntries (discovery=%t)...", discovery)
+	klog.InfoS("Begin createCHAPEntries...", "discovery", discovery)
 	if discovery {
 		args = append(baseArgs, []string{"-o", "update",
 			"-n", "discovery.sendtargets.auth.authmethod", "-v", "CHAP",
@@ -146,14 +148,14 @@ func createCHAPEntries(baseArgs []string, secrets Secrets, discovery bool) error
 
 // GetSessions retrieves a list of current iscsi sessions on the node
 func GetSessions() (string, error) {
-	debug.Println("Begin GetSessions...")
+	klog.InfoS("Begin GetSessions...")
 	out, err := iscsiCmd("-m", "session")
 	return out, err
 }
 
 // Login performs an iscsi login for the specified target
 func Login(tgtIQN, portal string) error {
-	debug.Println("Begin Login...")
+	klog.InfoS("Begin Login...")
 	baseArgs := []string{"-m", "node", "-T", tgtIQN, "-p", portal}
 	if _, err := iscsiCmd(append(baseArgs, []string{"-l"}...)...); err != nil {
 		//delete the node record from database
@@ -165,7 +167,7 @@ func Login(tgtIQN, portal string) error {
 
 // Logout logs out the specified target
 func Logout(tgtIQN, portal string) error {
-	debug.Println("Begin Logout...")
+	klog.InfoS("Begin Logout...")
 	args := []string{"-m", "node", "-T", tgtIQN, "-p", portal, "-u"}
 	iscsiCmd(args...)
 	return nil
@@ -173,7 +175,7 @@ func Logout(tgtIQN, portal string) error {
 
 // DeleteDBEntry deletes the iscsi db entry for the specified target
 func DeleteDBEntry(tgtIQN string) error {
-	debug.Println("Begin DeleteDBEntry...")
+	klog.InfoS("Begin DeleteDBEntry...")
 	args := []string{"-m", "node", "-T", tgtIQN, "-o", "delete"}
 	iscsiCmd(args...)
 	return nil
@@ -181,7 +183,7 @@ func DeleteDBEntry(tgtIQN string) error {
 
 // DeleteIFace delete the iface
 func DeleteIFace(iface string) error {
-	debug.Println("Begin DeleteIFace...")
+	klog.InfoS("Begin DeleteIFace...")
 	iscsiCmd([]string{"-m", "iface", "-I", iface, "-o", "delete"}...)
 	return nil
 }

--- a/iscsi/iscsiadm.go
+++ b/iscsi/iscsiadm.go
@@ -181,29 +181,25 @@ func GetSessions() (string, error) {
 
 // Login performs an iscsi login for the specified target
 func Login(tgtIQN, portal string) error {
+	debug.Println("Begin Login...")
 	baseArgs := []string{"-m", "node", "-T", tgtIQN, "-p", portal}
-	_, err := iscsiCmd(append(baseArgs, []string{"-l"}...)...)
-	if err != nil {
+	if _, err := iscsiCmd(append(baseArgs, []string{"-l"}...)...); err != nil {
 		//delete the node record from database
 		iscsiCmd(append(baseArgs, []string{"-o", "delete"}...)...)
 		return fmt.Errorf("failed to sendtargets to portal %s, err: %v", portal, err)
 	}
-	return err
-}
-
-// Logout logs out the specified target, if the target is not logged in it's not considered an error
-func Logout(tgtIQN string, portals []string) error {
-	debug.Println("Begin Logout...")
-	baseArgs := []string{"-m", "node", "-T", tgtIQN}
-	for _, p := range portals {
-		debug.Printf("attempting logout for portal: %s", p)
-		args := append(baseArgs, []string{"-p", p, "-u"}...)
-		iscsiCmd(args...)
-	}
 	return nil
 }
 
-// DeleteDBEntry deletes the iscsi db entry fo rthe specified target
+// Logout logs out the specified target
+func Logout(tgtIQN, portal string) error {
+	debug.Println("Begin Logout...")
+	args := []string{"-m", "node", "-T", tgtIQN, "-p", portal, "-u"}
+	iscsiCmd(args...)
+	return nil
+}
+
+// DeleteDBEntry deletes the iscsi db entry for the specified target
 func DeleteDBEntry(tgtIQN string) error {
 	debug.Println("Begin DeleteDBEntry...")
 	args := []string{"-m", "node", "-T", tgtIQN, "-o", "delete"}

--- a/iscsi/iscsiadm.go
+++ b/iscsi/iscsiadm.go
@@ -1,11 +1,11 @@
 package iscsi
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"time"
 
-	"github.com/go-logr/logr"
 	"k8s.io/klog/v2"
 )
 
@@ -23,8 +23,9 @@ type Secrets struct {
 	PasswordIn string `json:"passwordIn,omitempty"`
 }
 
-func iscsiCmd(logger *logr.Logger, args ...string) (string, error) {
-	stdout, err := execWithTimeout(logger, "iscsiadm", args, time.Second*3)
+func iscsiCmd(ctx context.Context, args ...string) (string, error) {
+	logger := klog.FromContext(ctx)
+	stdout, err := execWithTimeout(ctx, "iscsiadm", args, time.Second*3)
 
 	logger.V(1).Info("Run iscsiadm", "command", strings.Join(append([]string{"iscsiadm"}, args...), " "))
 	iscsiadmDebug(logger, string(stdout), err)
@@ -32,43 +33,46 @@ func iscsiCmd(logger *logr.Logger, args ...string) (string, error) {
 	return string(stdout), err
 }
 
-func iscsiadmDebug(logger *logr.Logger, output string, cmdError error) {
+func iscsiadmDebug(logger klog.Logger, output string, cmdError error) {
 	debugOutput := strings.Replace(output, "\n", "\\n", -1)
 	logger.V(1).Info("Output of iscsiadm command", "output", debugOutput)
 	if cmdError != nil {
-		klog.ErrorS(cmdError, "Error message returned from iscsiadm command")
+		logger.Error(cmdError, "Error message returned from iscsiadm command")
 	}
 }
 
 // ListInterfaces returns a list of all iscsi interfaces configured on the node
 /// along with the raw output in Response.StdOut we add the convenience of
 // returning a list of entries found
-func ListInterfaces(logger *logr.Logger) ([]string, error) {
+func ListInterfaces(ctx context.Context) ([]string, error) {
+	logger := klog.FromContext(ctx)
 	logger.V(1).Info("Begin ListInterface...")
-	out, err := iscsiCmd(logger, "-m", "iface", "-o", "show")
+	out, err := iscsiCmd(ctx, "-m", "iface", "-o", "show")
 	return strings.Split(out, "\n"), err
 }
 
 // ShowInterface retrieves the details for the specified iscsi interface
 // caller should inspect r.Err and use r.StdOut for interface details
-func ShowInterface(logger *logr.Logger, iface string) (string, error) {
+func ShowInterface(ctx context.Context, iface string) (string, error) {
+	logger := klog.FromContext(ctx)
 	logger.V(1).Info("Begin ShowInterface...")
-	out, err := iscsiCmd(logger, "-m", "iface", "-o", "show", "-I", iface)
+	out, err := iscsiCmd(ctx, "-m", "iface", "-o", "show", "-I", iface)
 	return out, err
 }
 
 // CreateDBEntry sets up a node entry for the specified tgt in the nodes iscsi nodes db
-func CreateDBEntry(logger *logr.Logger, tgtIQN, portal, iFace string, discoverySecrets, sessionSecrets Secrets) error {
+func CreateDBEntry(ctx context.Context, tgtIQN, portal, iFace string, discoverySecrets, sessionSecrets Secrets) error {
+	logger := klog.FromContext(ctx)
 	logger.V(1).Info("Begin CreateDBEntry...")
 	baseArgs := []string{"-m", "node", "-T", tgtIQN, "-p", portal}
-	_, err := iscsiCmd(logger, append(baseArgs, "-I", iFace, "-o", "new")...)
+	_, err := iscsiCmd(ctx, append(baseArgs, "-I", iFace, "-o", "new")...)
 	if err != nil {
 		return err
 	}
 
 	if discoverySecrets.SecretsType == "chap" {
 		logger.V(1).Info("Setting CHAP Discovery...")
-		err := createCHAPEntries(logger, baseArgs, discoverySecrets, true)
+		err := createCHAPEntries(ctx, baseArgs, discoverySecrets, true)
 		if err != nil {
 			return err
 		}
@@ -76,7 +80,7 @@ func CreateDBEntry(logger *logr.Logger, tgtIQN, portal, iFace string, discoveryS
 
 	if sessionSecrets.SecretsType == "chap" {
 		logger.V(1).Info("Setting CHAP Session...")
-		err := createCHAPEntries(logger, baseArgs, sessionSecrets, false)
+		err := createCHAPEntries(ctx, baseArgs, sessionSecrets, false)
 		if err != nil {
 			return err
 		}
@@ -87,31 +91,33 @@ func CreateDBEntry(logger *logr.Logger, tgtIQN, portal, iFace string, discoveryS
 }
 
 // Discoverydb discovers the iscsi target
-func Discoverydb(logger *logr.Logger, tp, iface string, discoverySecrets Secrets, chapDiscovery bool) error {
+func Discoverydb(ctx context.Context, tp, iface string, discoverySecrets Secrets, chapDiscovery bool) error {
+	logger := klog.FromContext(ctx)
 	logger.V(1).Info("Begin Discoverydb...")
 	baseArgs := []string{"-m", "discoverydb", "-t", "sendtargets", "-p", tp, "-I", iface}
-	out, err := iscsiCmd(logger, append(baseArgs, []string{"-o", "new"}...)...)
+	out, err := iscsiCmd(ctx, append(baseArgs, []string{"-o", "new"}...)...)
 	if err != nil {
 		return fmt.Errorf("failed to create new entry of target in discoverydb, output: %v, err: %v", out, err)
 	}
 
 	if chapDiscovery {
-		if err := createCHAPEntries(logger, baseArgs, discoverySecrets, true); err != nil {
+		if err := createCHAPEntries(ctx, baseArgs, discoverySecrets, true); err != nil {
 			return err
 		}
 	}
 
-	_, err = iscsiCmd(logger, append(baseArgs, []string{"--discover"}...)...)
+	_, err = iscsiCmd(ctx, append(baseArgs, []string{"--discover"}...)...)
 	if err != nil {
 		//delete the discoverydb record
-		iscsiCmd(logger, append(baseArgs, []string{"-o", "delete"}...)...)
+		iscsiCmd(ctx, append(baseArgs, []string{"-o", "delete"}...)...)
 		return fmt.Errorf("failed to sendtargets to portal %s, err: %v", tp, err)
 	}
 	return nil
 }
 
-func createCHAPEntries(logger *logr.Logger, baseArgs []string, secrets Secrets, discovery bool) error {
+func createCHAPEntries(ctx context.Context, baseArgs []string, secrets Secrets, discovery bool) error {
 	args := []string{}
+	logger := klog.FromContext(ctx)
 	logger.V(1).Info("Begin createCHAPEntries...", "discovery", discovery)
 	if discovery {
 		args = append(baseArgs, []string{"-o", "update",
@@ -139,7 +145,7 @@ func createCHAPEntries(logger *logr.Logger, baseArgs []string, secrets Secrets, 
 		}
 	}
 
-	_, err := iscsiCmd(logger, args...)
+	_, err := iscsiCmd(ctx, args...)
 	if err != nil {
 		return fmt.Errorf("failed to update discoverydb with CHAP, err: %v", err)
 	}
@@ -148,43 +154,48 @@ func createCHAPEntries(logger *logr.Logger, baseArgs []string, secrets Secrets, 
 }
 
 // GetSessions retrieves a list of current iscsi sessions on the node
-func GetSessions(logger *logr.Logger) (string, error) {
+func GetSessions(ctx context.Context) (string, error) {
+	logger := klog.FromContext(ctx)
 	logger.V(1).Info("Begin GetSessions...")
-	out, err := iscsiCmd(logger, "-m", "session")
+	out, err := iscsiCmd(ctx, "-m", "session")
 	return out, err
 }
 
 // Login performs an iscsi login for the specified target
-func Login(logger *logr.Logger, tgtIQN, portal string) error {
+func Login(ctx context.Context, tgtIQN, portal string) error {
+	logger := klog.FromContext(ctx)
 	logger.V(1).Info("Begin Login...")
 	baseArgs := []string{"-m", "node", "-T", tgtIQN, "-p", portal}
-	if _, err := iscsiCmd(logger, append(baseArgs, []string{"-l"}...)...); err != nil {
+	if _, err := iscsiCmd(ctx, append(baseArgs, []string{"-l"}...)...); err != nil {
 		//delete the node record from database
-		iscsiCmd(logger, append(baseArgs, []string{"-o", "delete"}...)...)
+		iscsiCmd(ctx, append(baseArgs, []string{"-o", "delete"}...)...)
 		return fmt.Errorf("failed to sendtargets to portal %s, err: %v", portal, err)
 	}
 	return nil
 }
 
 // Logout logs out the specified target
-func Logout(logger *logr.Logger, tgtIQN, portal string) error {
+func Logout(ctx context.Context, tgtIQN, portal string) error {
+	logger := klog.FromContext(ctx)
 	logger.V(1).Info("Begin Logout...")
 	args := []string{"-m", "node", "-T", tgtIQN, "-p", portal, "-u"}
-	iscsiCmd(logger, args...)
+	iscsiCmd(ctx, args...)
 	return nil
 }
 
 // DeleteDBEntry deletes the iscsi db entry for the specified target
-func DeleteDBEntry(logger *logr.Logger, tgtIQN string) error {
+func DeleteDBEntry(ctx context.Context, tgtIQN string) error {
+	logger := klog.FromContext(ctx)
 	logger.V(1).Info("Begin DeleteDBEntry...")
 	args := []string{"-m", "node", "-T", tgtIQN, "-o", "delete"}
-	iscsiCmd(logger, args...)
+	iscsiCmd(ctx, args...)
 	return nil
 }
 
 // DeleteIFace delete the iface
-func DeleteIFace(logger *logr.Logger, iface string) error {
+func DeleteIFace(ctx context.Context, iface string) error {
+	logger := klog.FromContext(ctx)
 	logger.V(1).Info("Begin DeleteIFace...")
-	iscsiCmd(logger, []string{"-m", "iface", "-I", iface, "-o", "delete"}...)
+	iscsiCmd(ctx, []string{"-m", "iface", "-I", iface, "-o", "delete"}...)
 	return nil
 }

--- a/iscsi/iscsiadm.go
+++ b/iscsi/iscsiadm.go
@@ -1,11 +1,11 @@
 package iscsi
 
 import (
-	"context"
 	"fmt"
 	"strings"
 	"time"
 
+	"github.com/go-logr/logr"
 	"k8s.io/klog/v2"
 )
 
@@ -23,18 +23,16 @@ type Secrets struct {
 	PasswordIn string `json:"passwordIn,omitempty"`
 }
 
-func iscsiCmd(ctx context.Context, args ...string) (string, error) {
-	logger := klog.FromContext(ctx)
-	stdout, err := execWithTimeout(ctx, "iscsiadm", args, time.Second*3)
+func iscsiCmd(logger *logr.Logger, args ...string) (string, error) {
+	stdout, err := execWithTimeout(logger, "iscsiadm", args, time.Second*3)
 
 	logger.V(1).Info("Run iscsiadm", "command", strings.Join(append([]string{"iscsiadm"}, args...), " "))
-	iscsiadmDebug(ctx, string(stdout), err)
+	iscsiadmDebug(logger, string(stdout), err)
 
 	return string(stdout), err
 }
 
-func iscsiadmDebug(ctx context.Context, output string, cmdError error) {
-	logger := klog.FromContext(ctx)
+func iscsiadmDebug(logger *logr.Logger, output string, cmdError error) {
 	debugOutput := strings.Replace(output, "\n", "\\n", -1)
 	logger.V(1).Info("Output of iscsiadm command", "output", debugOutput)
 	if cmdError != nil {
@@ -45,35 +43,32 @@ func iscsiadmDebug(ctx context.Context, output string, cmdError error) {
 // ListInterfaces returns a list of all iscsi interfaces configured on the node
 /// along with the raw output in Response.StdOut we add the convenience of
 // returning a list of entries found
-func ListInterfaces(ctx context.Context) ([]string, error) {
-	logger := klog.FromContext(ctx)
+func ListInterfaces(logger *logr.Logger) ([]string, error) {
 	logger.V(1).Info("Begin ListInterface...")
-	out, err := iscsiCmd(ctx, "-m", "iface", "-o", "show")
+	out, err := iscsiCmd(logger, "-m", "iface", "-o", "show")
 	return strings.Split(out, "\n"), err
 }
 
 // ShowInterface retrieves the details for the specified iscsi interface
 // caller should inspect r.Err and use r.StdOut for interface details
-func ShowInterface(ctx context.Context, iface string) (string, error) {
-	logger := klog.FromContext(ctx)
+func ShowInterface(logger *logr.Logger, iface string) (string, error) {
 	logger.V(1).Info("Begin ShowInterface...")
-	out, err := iscsiCmd(ctx, "-m", "iface", "-o", "show", "-I", iface)
+	out, err := iscsiCmd(logger, "-m", "iface", "-o", "show", "-I", iface)
 	return out, err
 }
 
 // CreateDBEntry sets up a node entry for the specified tgt in the nodes iscsi nodes db
-func CreateDBEntry(ctx context.Context, tgtIQN, portal, iFace string, discoverySecrets, sessionSecrets Secrets) error {
-	logger := klog.FromContext(ctx)
+func CreateDBEntry(logger *logr.Logger, tgtIQN, portal, iFace string, discoverySecrets, sessionSecrets Secrets) error {
 	logger.V(1).Info("Begin CreateDBEntry...")
 	baseArgs := []string{"-m", "node", "-T", tgtIQN, "-p", portal}
-	_, err := iscsiCmd(ctx, append(baseArgs, "-I", iFace, "-o", "new")...)
+	_, err := iscsiCmd(logger, append(baseArgs, "-I", iFace, "-o", "new")...)
 	if err != nil {
 		return err
 	}
 
 	if discoverySecrets.SecretsType == "chap" {
 		logger.V(1).Info("Setting CHAP Discovery...")
-		err := createCHAPEntries(ctx, baseArgs, discoverySecrets, true)
+		err := createCHAPEntries(logger, baseArgs, discoverySecrets, true)
 		if err != nil {
 			return err
 		}
@@ -81,7 +76,7 @@ func CreateDBEntry(ctx context.Context, tgtIQN, portal, iFace string, discoveryS
 
 	if sessionSecrets.SecretsType == "chap" {
 		logger.V(1).Info("Setting CHAP Session...")
-		err := createCHAPEntries(ctx, baseArgs, sessionSecrets, false)
+		err := createCHAPEntries(logger, baseArgs, sessionSecrets, false)
 		if err != nil {
 			return err
 		}
@@ -92,32 +87,30 @@ func CreateDBEntry(ctx context.Context, tgtIQN, portal, iFace string, discoveryS
 }
 
 // Discoverydb discovers the iscsi target
-func Discoverydb(ctx context.Context, tp, iface string, discoverySecrets Secrets, chapDiscovery bool) error {
-	logger := klog.FromContext(ctx)
+func Discoverydb(logger *logr.Logger, tp, iface string, discoverySecrets Secrets, chapDiscovery bool) error {
 	logger.V(1).Info("Begin Discoverydb...")
 	baseArgs := []string{"-m", "discoverydb", "-t", "sendtargets", "-p", tp, "-I", iface}
-	out, err := iscsiCmd(ctx, append(baseArgs, []string{"-o", "new"}...)...)
+	out, err := iscsiCmd(logger, append(baseArgs, []string{"-o", "new"}...)...)
 	if err != nil {
 		return fmt.Errorf("failed to create new entry of target in discoverydb, output: %v, err: %v", out, err)
 	}
 
 	if chapDiscovery {
-		if err := createCHAPEntries(ctx, baseArgs, discoverySecrets, true); err != nil {
+		if err := createCHAPEntries(logger, baseArgs, discoverySecrets, true); err != nil {
 			return err
 		}
 	}
 
-	_, err = iscsiCmd(ctx, append(baseArgs, []string{"--discover"}...)...)
+	_, err = iscsiCmd(logger, append(baseArgs, []string{"--discover"}...)...)
 	if err != nil {
 		//delete the discoverydb record
-		iscsiCmd(ctx, append(baseArgs, []string{"-o", "delete"}...)...)
+		iscsiCmd(logger, append(baseArgs, []string{"-o", "delete"}...)...)
 		return fmt.Errorf("failed to sendtargets to portal %s, err: %v", tp, err)
 	}
 	return nil
 }
 
-func createCHAPEntries(ctx context.Context, baseArgs []string, secrets Secrets, discovery bool) error {
-	logger := klog.FromContext(ctx)
+func createCHAPEntries(logger *logr.Logger, baseArgs []string, secrets Secrets, discovery bool) error {
 	args := []string{}
 	logger.V(1).Info("Begin createCHAPEntries...", "discovery", discovery)
 	if discovery {
@@ -146,7 +139,7 @@ func createCHAPEntries(ctx context.Context, baseArgs []string, secrets Secrets, 
 		}
 	}
 
-	_, err := iscsiCmd(ctx, args...)
+	_, err := iscsiCmd(logger, args...)
 	if err != nil {
 		return fmt.Errorf("failed to update discoverydb with CHAP, err: %v", err)
 	}
@@ -155,48 +148,43 @@ func createCHAPEntries(ctx context.Context, baseArgs []string, secrets Secrets, 
 }
 
 // GetSessions retrieves a list of current iscsi sessions on the node
-func GetSessions(ctx context.Context) (string, error) {
-	logger := klog.FromContext(ctx)
+func GetSessions(logger *logr.Logger) (string, error) {
 	logger.V(1).Info("Begin GetSessions...")
-	out, err := iscsiCmd(ctx, "-m", "session")
+	out, err := iscsiCmd(logger, "-m", "session")
 	return out, err
 }
 
 // Login performs an iscsi login for the specified target
-func Login(ctx context.Context, tgtIQN, portal string) error {
-	logger := klog.FromContext(ctx)
+func Login(logger *logr.Logger, tgtIQN, portal string) error {
 	logger.V(1).Info("Begin Login...")
 	baseArgs := []string{"-m", "node", "-T", tgtIQN, "-p", portal}
-	if _, err := iscsiCmd(ctx, append(baseArgs, []string{"-l"}...)...); err != nil {
+	if _, err := iscsiCmd(logger, append(baseArgs, []string{"-l"}...)...); err != nil {
 		//delete the node record from database
-		iscsiCmd(ctx, append(baseArgs, []string{"-o", "delete"}...)...)
+		iscsiCmd(logger, append(baseArgs, []string{"-o", "delete"}...)...)
 		return fmt.Errorf("failed to sendtargets to portal %s, err: %v", portal, err)
 	}
 	return nil
 }
 
 // Logout logs out the specified target
-func Logout(ctx context.Context, tgtIQN, portal string) error {
-	logger := klog.FromContext(ctx)
+func Logout(logger *logr.Logger, tgtIQN, portal string) error {
 	logger.V(1).Info("Begin Logout...")
 	args := []string{"-m", "node", "-T", tgtIQN, "-p", portal, "-u"}
-	iscsiCmd(ctx, args...)
+	iscsiCmd(logger, args...)
 	return nil
 }
 
 // DeleteDBEntry deletes the iscsi db entry for the specified target
-func DeleteDBEntry(ctx context.Context, tgtIQN string) error {
-	logger := klog.FromContext(ctx)
+func DeleteDBEntry(logger *logr.Logger, tgtIQN string) error {
 	logger.V(1).Info("Begin DeleteDBEntry...")
 	args := []string{"-m", "node", "-T", tgtIQN, "-o", "delete"}
-	iscsiCmd(ctx, args...)
+	iscsiCmd(logger, args...)
 	return nil
 }
 
 // DeleteIFace delete the iface
-func DeleteIFace(ctx context.Context, iface string) error {
-	logger := klog.FromContext(ctx)
+func DeleteIFace(logger *logr.Logger, iface string) error {
 	logger.V(1).Info("Begin DeleteIFace...")
-	iscsiCmd(ctx, []string{"-m", "iface", "-I", iface, "-o", "delete"}...)
+	iscsiCmd(logger, []string{"-m", "iface", "-I", iface, "-o", "delete"}...)
 	return nil
 }

--- a/iscsi/iscsiadm.go
+++ b/iscsi/iscsiadm.go
@@ -116,7 +116,7 @@ func Discoverydb(tp, iface string, discoverySecrets Secrets, chapDiscovery bool)
 	baseArgs := []string{"-m", "discoverydb", "-t", "sendtargets", "-p", tp, "-I", iface}
 	out, err := iscsiCmd(append(baseArgs, []string{"-o", "new"}...)...)
 	if err != nil {
-		return fmt.Errorf("failed to create new entry of target in discoverydb, output: %v, err: %v", string(out), err)
+		return fmt.Errorf("failed to create new entry of target in discoverydb, output: %v, err: %v", out, err)
 	}
 
 	if chapDiscovery {

--- a/iscsi/iscsiadm_test.go
+++ b/iscsi/iscsiadm_test.go
@@ -1,9 +1,12 @@
 package iscsi
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/prashantv/gostub"
+)
 
 func TestDiscovery(t *testing.T) {
-	execCommand = fakeExecCommand
 	tests := map[string]struct {
 		tgtPortal        string
 		iface            string
@@ -63,8 +66,7 @@ iscsiadm: Could not perform SendTargets discovery.\n`,
 
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			mockedExitStatus = tt.mockedExitStatus
-			mockedStdout = tt.mockedStdout
+			defer gostub.Stub(&execCommand, makeFakeExecCommand(tt.mockedExitStatus, tt.mockedStdout)).Reset()
 			err := Discoverydb(tt.tgtPortal, tt.iface, tt.discoverySecret, tt.chapDiscovery)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Discoverydb() error = %v, wantErr %v", err, tt.wantErr)
@@ -75,7 +77,6 @@ iscsiadm: Could not perform SendTargets discovery.\n`,
 }
 
 func TestCreateDBEntry(t *testing.T) {
-	execCommand = fakeExecCommand
 	tests := map[string]struct {
 		tgtPortal        string
 		tgtIQN           string
@@ -115,8 +116,7 @@ func TestCreateDBEntry(t *testing.T) {
 
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			mockedExitStatus = tt.mockedExitStatus
-			mockedStdout = tt.mockedStdout
+			defer gostub.Stub(&execCommand, makeFakeExecCommand(tt.mockedExitStatus, tt.mockedStdout)).Reset()
 			err := CreateDBEntry(tt.tgtIQN, tt.tgtPortal, tt.iface, tt.discoverySecret, tt.sessionSecret)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("CreateDBEntry() error = %v, wantErr %v", err, tt.wantErr)

--- a/iscsi/iscsiadm_test.go
+++ b/iscsi/iscsiadm_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/prashantv/gostub"
 	"github.com/stretchr/testify/assert"
+	"k8s.io/klog/v2/ktesting"
 )
 
 const defaultInterface = `
@@ -68,6 +69,7 @@ iface.discovery_logout = <empty>
 `
 
 func TestDiscovery(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
 	tests := map[string]struct {
 		tgtPortal       string
 		iface           string
@@ -127,8 +129,8 @@ iscsiadm: Could not perform SendTargets discovery.\n`,
 
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			defer gostub.Stub(&execWithTimeout, makeFakeExecWithTimeout(false, []byte(tt.mockedStdout), tt.mockedCmdError)).Reset()
-			err := Discoverydb(tt.tgtPortal, tt.iface, tt.discoverySecret, tt.chapDiscovery)
+			defer gostub.Stub(&execWithTimeout, makeFakeExecWithTimeout(ctx, false, []byte(tt.mockedStdout), tt.mockedCmdError)).Reset()
+			err := Discoverydb(ctx, tt.tgtPortal, tt.iface, tt.discoverySecret, tt.chapDiscovery)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Discoverydb() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -138,6 +140,7 @@ iscsiadm: Could not perform SendTargets discovery.\n`,
 }
 
 func TestCreateDBEntry(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
 	tests := map[string]struct {
 		tgtPortal       string
 		tgtIQN          string
@@ -177,8 +180,8 @@ func TestCreateDBEntry(t *testing.T) {
 
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			defer gostub.Stub(&execWithTimeout, makeFakeExecWithTimeout(false, []byte(tt.mockedStdout), tt.mockedCmdError)).Reset()
-			err := CreateDBEntry(tt.tgtIQN, tt.tgtPortal, tt.iface, tt.discoverySecret, tt.sessionSecret)
+			defer gostub.Stub(&execWithTimeout, makeFakeExecWithTimeout(ctx, false, []byte(tt.mockedStdout), tt.mockedCmdError)).Reset()
+			err := CreateDBEntry(ctx, tt.tgtIQN, tt.tgtPortal, tt.iface, tt.discoverySecret, tt.sessionSecret)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("CreateDBEntry() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -189,6 +192,7 @@ func TestCreateDBEntry(t *testing.T) {
 }
 
 func TestListInterfaces(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
 	tests := map[string]struct {
 		mockedStdout   string
 		mockedCmdError error
@@ -224,8 +228,8 @@ func TestListInterfaces(t *testing.T) {
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
 			assert := assert.New(t)
-			defer gostub.Stub(&execWithTimeout, makeFakeExecWithTimeout(false, []byte(tt.mockedStdout), tt.mockedCmdError)).Reset()
-			interfaces, err := ListInterfaces()
+			defer gostub.Stub(&execWithTimeout, makeFakeExecWithTimeout(ctx, false, []byte(tt.mockedStdout), tt.mockedCmdError)).Reset()
+			interfaces, err := ListInterfaces(ctx)
 
 			if tt.wantErr {
 				assert.NotNil(err)
@@ -238,6 +242,7 @@ func TestListInterfaces(t *testing.T) {
 }
 
 func TestShowInterface(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
 	tests := map[string]struct {
 		mockedStdout   string
 		mockedCmdError error
@@ -261,8 +266,8 @@ func TestShowInterface(t *testing.T) {
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
 			assert := assert.New(t)
-			defer gostub.Stub(&execWithTimeout, makeFakeExecWithTimeout(false, []byte(tt.mockedStdout), tt.mockedCmdError)).Reset()
-			interfaces, err := ShowInterface("default")
+			defer gostub.Stub(&execWithTimeout, makeFakeExecWithTimeout(ctx, false, []byte(tt.mockedStdout), tt.mockedCmdError)).Reset()
+			interfaces, err := ShowInterface(ctx, "default")
 
 			if tt.wantErr {
 				assert.NotNil(err)

--- a/iscsi/multipath.go
+++ b/iscsi/multipath.go
@@ -2,25 +2,20 @@ package iscsi
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"time"
-	"encoding/json"
 )
-
-var sysBlockPath = "/sys/block"
-var sysScsiPath = "/sys/class/scsi_device"
-var devPath = "/dev"
 
 type multipathDeviceMap struct {
 	Map multipathMap `json:"map"`
 }
 
 type multipathMap struct {
-	Name string `json:"name"`
-	Uuid string `json:"uuid"`
-	Sysfs string `json:"sysfs"`
+	Name       string      `json:"name"`
+	UUID       string      `json:"uuid"`
+	Sysfs      string      `json:"sysfs"`
 	PathGroups []pathGroup `json:"path_groups"`
 }
 
@@ -32,6 +27,7 @@ type path struct {
 	Device string `json:"dev"`
 }
 
+// ExecWithTimeout execute a command with a timeout and returns an error if timeout is excedeed
 func ExecWithTimeout(command string, args []string, timeout time.Duration) ([]byte, error) {
 	debug.Printf("Executing command '%v' with args: '%v'.\n", command, args)
 
@@ -53,8 +49,6 @@ func ExecWithTimeout(command string, args []string, timeout time.Duration) ([]by
 		return nil, ctx.Err()
 	}
 
-	// If there's no context error, we know the command completed (or errored).
-	debug.Printf("Output from command: %s", string(out))
 	if err != nil {
 		debug.Printf("Non-zero exit code: %s\n", err)
 	}
@@ -64,7 +58,7 @@ func ExecWithTimeout(command string, args []string, timeout time.Duration) ([]by
 }
 
 func getMultipathMap(device string) (*multipathDeviceMap, error) {
-	debug.Printf("Getting multipath map for device %s.\n", device[1:])
+	debug.Printf("Getting multipath map for device %s.\n", device)
 
 	cmd := exec.Command("multipathd", "show", "map", device[1:], "json")
 	out, err := cmd.Output()
@@ -74,8 +68,11 @@ func getMultipathMap(device string) (*multipathDeviceMap, error) {
 		return nil, err
 	}
 
-	var deviceMap multipathDeviceMap;
-	json.Unmarshal(out, &deviceMap)
+	var deviceMap multipathDeviceMap
+	err = json.Unmarshal(out, &deviceMap)
+	if err != nil {
+		return nil, err
+	}
 	return &deviceMap, nil
 }
 
@@ -91,40 +88,23 @@ func (deviceMap *multipathDeviceMap) GetSlaves() []string {
 	return slaves
 }
 
-// GetScsiDevicesFromMultipathDevice gets all ScsiDevice for multipath device dm-x
-func GetScsiDevicesFromMultipathDevice(device string) ([]string, error) {
-	debug.Printf("Getting all slaves for multipath device %s.\n", device)
-
-	deviceMap, err := getMultipathMap(device)
-
-	if err != nil {
-		debug.Printf("An error occured while looking for slaves: %v\n", err)
-		return nil, err
-	}
-
-	slaves := deviceMap.GetSlaves()
-
-	debug.Printf("Found slaves: %v.\n", slaves)
-	return slaves, nil
-}
-
 // FlushMultipathDevice flushes a multipath device dm-x with command multipath -f /dev/dm-x
-func FlushMultipathDevice(device string) error {
-	debug.Printf("Flushing multipath device '%v'.\n", device)
+func FlushMultipathDevice(device *Device) error {
+	devicePath := device.GetPath()
+	debug.Printf("Flushing multipath device '%v'.\n", devicePath)
 
-	fullDevice := filepath.Join(devPath, device)
 	timeout := 5 * time.Second
-	_, err := execWithTimeout("multipath", []string{"-f", fullDevice}, timeout)
+	_, err := execWithTimeout("multipath", []string{"-f", devicePath}, timeout)
 
 	if err != nil {
-		if _, e := os.Stat(fullDevice); os.IsNotExist(e) {
-			debug.Printf("Multipath device %v was deleted.\n", device)
+		if _, e := os.Stat(devicePath); os.IsNotExist(e) {
+			debug.Printf("Multipath device %v has been removed.\n", devicePath)
 		} else {
-			debug.Printf("Command 'multipath -f %v' did not succeed to delete the device: %v\n", fullDevice, err)
+			debug.Printf("Command 'multipath -f %v' did not succeed to delete the device: %v\n", devicePath, err)
 			return err
 		}
 	}
 
-	debug.Printf("Finshed flushing multipath device %v.\n", device)
+	debug.Printf("Finshed flushing multipath device %v.\n", devicePath)
 	return nil
 }

--- a/iscsi/multipath.go
+++ b/iscsi/multipath.go
@@ -116,3 +116,14 @@ func FlushMultipathDevice(device *Device) error {
 	debug.Printf("Finshed flushing multipath device %v.\n", devicePath)
 	return nil
 }
+
+// ResizeMultipathDevice resize a multipath device based on its underlying devices
+func ResizeMultipathDevice(device *Device) error {
+	debug.Printf("Resizing multipath device %s\n", device.GetPath())
+
+	if output, err := exec.Command("multipathd", "resize", "map", device.Name).CombinedOutput(); err != nil {
+		return fmt.Errorf("could not resize multipath device: %s (%v)", output, err)
+	}
+
+	return nil
+}

--- a/iscsi/multipath.go
+++ b/iscsi/multipath.go
@@ -38,7 +38,7 @@ func ExecWithTimeout(command string, args []string, timeout time.Duration) ([]by
 	defer cancel()
 
 	// Create command with context
-	cmd := exec.CommandContext(ctx, command, args...)
+	cmd := execCommandContext(ctx, command, args...)
 
 	// This time we can simply use Output() to get the result.
 	out, err := cmd.Output()
@@ -65,7 +65,7 @@ func ExecWithTimeout(command string, args []string, timeout time.Duration) ([]by
 func getMultipathMap(device string) (*multipathDeviceMap, error) {
 	debug.Printf("Getting multipath map for device %s.\n", device)
 
-	cmd := exec.Command("multipathd", "show", "map", device[1:], "json")
+	cmd := execCommand("multipathd", "show", "map", device[1:], "json")
 	out, err := cmd.CombinedOutput()
 	// debug.Printf(string(out))
 	if err != nil {
@@ -102,7 +102,7 @@ func FlushMultipathDevice(device *Device) error {
 	_, err := execWithTimeout("multipath", []string{"-f", devicePath}, timeout)
 
 	if err != nil {
-		if _, e := os.Stat(devicePath); os.IsNotExist(e) {
+		if _, e := osStat(devicePath); os.IsNotExist(e) {
 			debug.Printf("Multipath device %v has been removed.\n", devicePath)
 		} else {
 			if strings.Contains(err.Error(), "map in use") {
@@ -121,7 +121,7 @@ func FlushMultipathDevice(device *Device) error {
 func ResizeMultipathDevice(device *Device) error {
 	debug.Printf("Resizing multipath device %s\n", device.GetPath())
 
-	if output, err := exec.Command("multipathd", "resize", "map", device.Name).CombinedOutput(); err != nil {
+	if output, err := execCommand("multipathd", "resize", "map", device.Name).CombinedOutput(); err != nil {
 		return fmt.Errorf("could not resize multipath device: %s (%v)", output, err)
 	}
 

--- a/iscsi/multipath.go
+++ b/iscsi/multipath.go
@@ -2,20 +2,13 @@ package iscsi
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"strings"
 	"time"
 )
-
-type pathGroup struct {
-	Paths []path `json:"paths"`
-}
-
-type path struct {
-	Device string `json:"dev"`
-}
 
 // ExecWithTimeout execute a command with a timeout and returns an error if timeout is excedeed
 func ExecWithTimeout(command string, args []string, timeout time.Duration) ([]byte, error) {
@@ -35,13 +28,14 @@ func ExecWithTimeout(command string, args []string, timeout time.Duration) ([]by
 	// We want to check the context error to see if the timeout was executed.
 	// The error returned by cmd.Output() will be OS specific based on what
 	// happens when a process is killed.
-	if ctx.Err() == context.DeadlineExceeded {
+	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 		debug.Printf("Command '%s' timeout reached.\n", command)
 		return nil, ctx.Err()
 	}
 
 	if err != nil {
-		if ee, ok := err.(*exec.ExitError); ok {
+		var ee *exec.ExitError
+		if ok := errors.Is(err, ee); ok {
 			debug.Printf("Non-zero exit code: %s\n", err)
 			err = fmt.Errorf("%s", ee.Stderr)
 		}

--- a/iscsi/multipath.go
+++ b/iscsi/multipath.go
@@ -9,12 +9,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/go-logr/logr"
 	"k8s.io/klog/v2"
 )
 
 // ExecWithTimeout execute a command with a timeout and returns an error if timeout is excedeed
-func ExecWithTimeout(ctx context.Context, command string, args []string, timeout time.Duration) ([]byte, error) {
-	logger := klog.FromContext(ctx)
+func ExecWithTimeout(logger *logr.Logger, command string, args []string, timeout time.Duration) ([]byte, error) {
 	logger.V(1).Info("Executing command with timeout", "command", command, "args", args)
 
 	// Create a new context and add a timeout to it
@@ -50,13 +50,12 @@ func ExecWithTimeout(ctx context.Context, command string, args []string, timeout
 }
 
 // FlushMultipathDevice flushes a multipath device dm-x with command multipath -f /dev/dm-x
-func FlushMultipathDevice(ctx context.Context, device *Device) error {
+func FlushMultipathDevice(logger *logr.Logger, device *Device) error {
 	devicePath := device.GetPath()
-	logger := klog.FromContext(ctx)
 	logger.V(1).Info("Flushing multipath device", "device", devicePath)
 
 	timeout := 5 * time.Second
-	_, err := execWithTimeout(ctx, "multipath", []string{"-f", devicePath}, timeout)
+	_, err := execWithTimeout(logger, "multipath", []string{"-f", devicePath}, timeout)
 
 	if err != nil {
 		if _, e := osStat(devicePath); os.IsNotExist(e) {

--- a/iscsi/multipath_test.go
+++ b/iscsi/multipath_test.go
@@ -8,9 +8,11 @@ import (
 
 	"github.com/prashantv/gostub"
 	"github.com/stretchr/testify/assert"
+	"k8s.io/klog/v2/ktesting"
 )
 
 func TestExecWithTimeout(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
 	tests := map[string]struct {
 		mockedStdout     string
 		mockedExitStatus int
@@ -58,7 +60,7 @@ func TestExecWithTimeout(t *testing.T) {
 				return makeFakeExecCommandContext(tt.mockedExitStatus, tt.mockedStdout)(ctx, command, args...)
 			}).Reset()
 
-			out, err := ExecWithTimeout("dummy", []string{}, timeout)
+			out, err := ExecWithTimeout(ctx, "dummy", []string{}, timeout)
 
 			if tt.wantTimeout || tt.mockedExitStatus != 0 {
 				assert.NotNil(err)

--- a/iscsi/multipath_test.go
+++ b/iscsi/multipath_test.go
@@ -1,0 +1,79 @@
+package iscsi
+
+import (
+	"context"
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/prashantv/gostub"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExecWithTimeout(t *testing.T) {
+	tests := map[string]struct {
+		mockedStdout     string
+		mockedExitStatus int
+		wantTimeout      bool
+	}{
+		"Success": {
+			mockedStdout:     "some output",
+			mockedExitStatus: 0,
+			wantTimeout:      false,
+		},
+		"WithError": {
+			mockedStdout:     "some\noutput",
+			mockedExitStatus: 1,
+			wantTimeout:      false,
+		},
+		"WithTimeout": {
+			mockedStdout:     "",
+			mockedExitStatus: 0,
+			wantTimeout:      true,
+		},
+		"WithTimeoutAndOutput": {
+			mockedStdout:     "should not be returned",
+			mockedExitStatus: 0,
+			wantTimeout:      true,
+		},
+		"WithTimeoutAndError": {
+			mockedStdout:     "",
+			mockedExitStatus: 1,
+			wantTimeout:      true,
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			timeout := time.Second
+			if tt.wantTimeout {
+				timeout = time.Millisecond * 50
+			}
+
+			defer gostub.Stub(&execCommandContext, func(ctx context.Context, command string, args ...string) *exec.Cmd {
+				if tt.wantTimeout {
+					time.Sleep(timeout + time.Millisecond*10)
+				}
+				return makeFakeExecCommandContext(tt.mockedExitStatus, tt.mockedStdout)(ctx, command, args...)
+			}).Reset()
+
+			out, err := ExecWithTimeout("dummy", []string{}, timeout)
+
+			if tt.wantTimeout || tt.mockedExitStatus != 0 {
+				assert.NotNil(err)
+				if tt.wantTimeout {
+					assert.Equal(context.DeadlineExceeded, err)
+				}
+			} else {
+				assert.Nil(err)
+			}
+
+			if tt.wantTimeout {
+				assert.Equal("", string(out))
+			} else {
+				assert.Equal(tt.mockedStdout, string(out))
+			}
+		})
+	}
+}


### PR DESCRIPTION
Related to https://kubernetes.io/blog/2022/05/25/contextual-logging/ and https://github.com/kubernetes/enhancements/blob/master/keps/sig-instrumentation/1602-structured-logging/README.md

The main reason for this change is to allow drivers and libraries to use the same klog logging package, and to switch to using structured logging throughout the library. From my understanding, klog is the most common Kubernetes logger and this allows consistent log output for CSI drivers and the iSCSI library.

Signed-off-by: Joe Skazinski [joseph.skazinski@seagate.com](mailto:joseph.skazinski@seagate.com)

What type of PR is this?
/kind feature

What this PR does / why we need it:

Converts the library to using "k8s.io/klog/v2" and specifically structured logging.
Addresses one issue allowing the code to work with older and newer versions of lsblk.

Which issue(s) this PR fixes:

Special notes for your reviewer:
This change does not disable logging by default, but does allow the user to set their own io.Writer. This is a change from the prior default behavior. This change uses structured logging and captures the same information with no loss, but with the possibility of additional information being provided where it proves useful in the particular context.

Does this PR introduce a user-facing change?:
Yes, the structure of the log information is presented in the klog format versus the prior formatting. Each log entry contains the same relevant information, such as timestamp and level (Info vs Error), and library values, but the the text outline is changed and will affect any scripts scraping the logs.

Refactored to use klog/v2 and structured logging.
- Switched to using go 1.18 
- using k8s.io/klog/v2 klog replacing log.Logger
- init() prints a version message but does not disable logging
- EnableDebugLogging() allows a caller to set their own io.Writer
- debug.Printf calls are replaced with klog.InfoS and klog.ErrorS (according to info versus error)
- getMultipathDevice() was altered to work with older versions of lsblk output and newer versions. See https://github.com/kubernetes-csi/csi-lib-iscsi/issues/34

-----
[View rendered README.md](https://github.com/Seagate/csi-lib-iscsi/blob/refactor/klogs/README.md)