### PR TITLE
persist connector logging update for CHAP support in CSI

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -55,7 +55,7 @@ func main() {
 
 	// Now we can just issue a connection request using our Connector
 	// A succesful connection will include the device path to access our iscsi volume
-	path, err := iscsi.Connect(c)
+	path, err := iscsi.Connect(&c)
 	if err != nil {
 		log.Printf("Error returned from iscsi.Connect: %s", err.Error())
 		os.Exit(1)

--- a/iscsi/iscsi.go
+++ b/iscsi/iscsi.go
@@ -480,7 +480,7 @@ func PersistConnector(c *Connector, filePath string) error {
 	}
 	defer f.Close()
 	encoder := json.NewEncoder(f)
-	debug.Printf("Connector Persistence File (write): file=%v\n", filePath)
+	debug.Printf("Connector Persistence File (write): file=%s\n", filePath)
 	if err = encoder.Encode(c); err != nil {
 		debug.Printf("ERROR: error encoding connector: %v\n", err)
 		return fmt.Errorf("error encoding connector: %v", err)

--- a/iscsi/iscsi.go
+++ b/iscsi/iscsi.go
@@ -45,7 +45,7 @@ type TargetInfo struct {
 	Port   string `json:"port"`
 }
 
-//Connector provides a struct to hold all of the needed parameters to make our iscsi connection
+// Connector provides a struct to hold all of the needed parameters to make our iscsi connection
 type Connector struct {
 	VolumeName       string       `json:"volume_name"`
 	Targets          []TargetInfo `json:"targets"`
@@ -385,7 +385,7 @@ func Connect(c *Connector) (string, error) {
 	return "", err
 }
 
-//Disconnect performs a disconnect operation on a volume
+// Disconnect performs a disconnect operation on a volume
 func Disconnect(tgtIqn string, portals []string) error {
 	err := Logout(tgtIqn, portals)
 	if err != nil {
@@ -480,7 +480,7 @@ func PersistConnector(c *Connector, filePath string) error {
 	}
 	defer f.Close()
 	encoder := json.NewEncoder(f)
-	debug.Printf("ConnectorFromFile (write): file=%v, c=%+v\n", filePath, c)
+	debug.Printf("Connector Persistence File (write): file=%v\n", filePath)
 	if err = encoder.Encode(c); err != nil {
 		debug.Printf("ERROR: error encoding connector: %v\n", err)
 		return fmt.Errorf("error encoding connector: %v", err)
@@ -503,7 +503,7 @@ func GetConnectorFromFile(filePath string) (*Connector, error) {
 		return &Connector{}, err
 	}
 
-	debug.Printf("ConnectorFromFile (read): file=%s, %+v\n", filePath, data)
+	debug.Printf("ConnectorFromFile (read): file=%s\n", filePath)
 
 	return &data, nil
 


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**: The code currently logs the full connector struct in the connector persistence function. This PR removes this logging as it could cause CHAP secrets contained in the connector to be logged. Also updates the example program to fix a bug.